### PR TITLE
new .executeAction() API for StoreMixin

### DIFF
--- a/mixins/StoreMixin.js
+++ b/mixins/StoreMixin.js
@@ -177,6 +177,18 @@ StoreMixin = {
             listener.store.removeChangeListener(listener.handler);
         });
         this.listeners = [];
+    },
+
+    /**
+     * wrap context executeAction
+     * @method executeAction
+     */
+    executeAction: function () {
+        if (!this.props.context) {
+            throw new Error('storeListener mixin was called but no context was provided for executeAction()');
+        }
+
+        return this.props.context.executeAction.apply(this.props.context, arguments);
     }
 };
 

--- a/tests/unit/mixins/StoreMixin.js
+++ b/tests/unit/mixins/StoreMixin.js
@@ -169,6 +169,20 @@ describe('StoreListenerMixin', function () {
     });
 
     describe('executeAction', function () {
+        it('should throw when no context provided', function () {
+            var Component = React.createClass({
+                mixins: [StoreMixin],
+                getInitialState: function () {
+                    this.executeAction(function () {},2,function(){});
+                    return {};
+                },
+                render: function () { return null; }
+            });
+           
+            expect(function () {
+                ReactTestUtils.renderIntoDocument(Component());
+            }).to.throw();
+        });
         it('should call context executeAction when context provided', function () {
             var Component = React.createClass({
                 mixins: [StoreMixin],

--- a/tests/unit/mixins/StoreMixin.js
+++ b/tests/unit/mixins/StoreMixin.js
@@ -167,4 +167,20 @@ describe('StoreListenerMixin', function () {
             expect(StoreMixin.listeners).to.have.length(0);
         });
     });
+
+    describe('executeAction', function () {
+        it('should call context executeAction when context provided', function () {
+            var Component = React.createClass({
+                mixins: [StoreMixin],
+                getInitialState: function () {
+                    this.executeAction(function () {},2,function(){});
+                    return {};
+                },
+                render: function () { return null; }
+            }),
+            component = ReactTestUtils.renderIntoDocument(Component({context: context}));
+
+            expect(context.executeActionCalls).to.have.length(1);
+        });
+    });
 });


### PR DESCRIPTION
This patch wraps `this.props.context.executeAction()` to `this.executeAction()` to stop expose context location in code of components.

**Before:**
```javascript
// inside a component....
this.props.context.executeAction(xxxxxx);
```

**After:**
```javascript
// inside a component....
this.executeAction(xxxxxx);
```

When the context location moved to other place or the context solution changes, this will make all components safe from these change.

Possible context solutions:
https://github.com/brianmcd/contextify
https://www.tildedave.com/2014/11/15/introduction-to-contexts-in-react-js.html