### PR TITLE
withContext doesn't inherit, hasOwnProperty only

### DIFF
--- a/utils/MockComponentContext.js
+++ b/utils/MockComponentContext.js
@@ -15,6 +15,8 @@ module.exports = function createMockComponentContextClass() {
     function MockComponentContext () {
         this.dispatcher = new Dispatcher();
         this.executeActionCalls = [];
+        this.getStore = this.getStore.bind(this);
+        this.executeAction = this.executeAction.bind(this);
     }
 
     MockComponentContext.prototype.getStore = function (name) {


### PR DESCRIPTION
When writing tests and using `withContext` the `getStore` and `executeAction` methods don't get passed unless they are properties on the context object itself, inheritence doesn't work. `bind` is used because when contexts are added they are mixed into the current context and the reference to `this.dispatcher` would be lost.

Alternatively, it would be easy to move the methods into the constructor and out of the prototype entirely. Let me know if that would be preferred to this.

Inheritance simply doesn't work:
```js
var MyClass = React.createClass({
    contextTypes: {
        hello: React.PropTypes.func.isRequired
    },
    render: function () {
        return React.createElement('div', null, this.context.hello());
    }
});

var contextPrototype = {
    hello: function () { return 'hello' }
};

function BrokenContext() {}
BrokenContext.prototype = contextPrototype;

function WorkingContext() {
    // This adds the key to the current object
    this.hello = this.hello;
}
WorkingContext.prototype = contextPrototype;

// Fails
React.withContext(new BrokenContext(), function () {
    React.render(React.createElement(MyClass), document.body);
});

// Succeeds
React.withContext({
    hello: function () { return 'hello' }
}, function () {
    React.render(React.createElement(MyClass), document.body);
});

// Fix broken inheritance
React.withContext(new WorkingContext(), function () {
    React.render(React.createElement(MyClass), document.body);
});
```

Why `bind` is necessary:
```js
var MyClass = React.createClass({
    contextTypes: {
        hello: React.PropTypes.func.isRequired
    },
    render: function () {
        return React.createElement('div', null, this.context.hello() || 'Failed');
    }
});

var contextPrototype = {
    hello: function () { return this.helloText }
};

function BrokenContext() {
    this.helloText = 'hello';
    this.hello = this.hello;
}
BrokenContext.prototype = contextPrototype;

function WorkingContext() {
    this.helloText = 'hello';
    // The bind here ensures this.helloText will be accessible without adding it to the contextTypes
    this.hello = this.hello.bind(this);
}
WorkingContext.prototype = contextPrototype;

// Fails
React.withContext(new BrokenContext(), function () {
    React.render(React.createElement(MyClass), document.body);
});

// Succeeds
React.withContext(new WorkingContext(), function () {
    React.render(React.createElement(MyClass), document.body);
});
```