### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluxible",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A pluggable container for isomorphic flux applications",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Didn't know the repo didn't have auto-bumping.
Need this to get `MockComponentContext` changes into npm.
https://github.com/yahoo/fluxible/pull/45