### PR TITLE
Provide the current context as a child context.

### DIFF
--- a/mixins/FluxibleMixin.js
+++ b/mixins/FluxibleMixin.js
@@ -42,6 +42,24 @@ var FluxibleMixin = {
         getStore: React.PropTypes.func,
         executeAction: React.PropTypes.func
     },
+
+    childContextTypes: {
+        getStore: React.PropTypes.func,
+        executeAction: React.PropTypes.func
+    },
+
+    /**
+     * Provides the current context as a child context
+     * @method getChildContext
+     */
+    getChildContext: function(){
+        var context = {};
+        Object.keys(FluxibleMixin.childContextTypes).forEach(function (key) {
+            context[key] = (this.props.context && this.props.context[key]) || this.context[key];
+        }, this);
+        return context;
+    },
+
     /**
      * Registers staticly declared listeners
      * @method componentDidMount

--- a/tests/unit/mixins/FluxibleMixin.js
+++ b/tests/unit/mixins/FluxibleMixin.js
@@ -41,6 +41,71 @@ describe('StoreListenerMixin', function () {
         delete global.navigator;
     });
 
+    describe('getChildContext', function(){
+        it('should return the context', function (done) {
+            var Component = React.createClass({
+                mixins: [FluxibleMixin],
+                statics: {
+                    storeListeners: [MockStore]
+                },
+                onChange: function () {
+                    done();
+                },
+                render: function () { return null; }
+            });
+            var Element = React.createFactory(Component);
+            var component = ReactTestUtils.renderIntoDocument(Element({context: context}));
+            var childContext = component.getChildContext();
+            expect(childContext).to.exist;
+            expect(childContext).to.be.an('object');
+            expect(childContext.getStore).to.be.an('function');
+            expect(childContext.executeAction).to.be.an('function');
+            mockStore.emitChange();
+        });
+        it('should propagate the context to child components', function (done) {
+            var childContext1, childContext2;
+            var ChildComponent1 = React.createClass({
+                mixins: [FluxibleMixin],
+                componentDidMount: function(){
+                    childContext1 = this.getChildContext();
+                },
+                render: function () { return null; }
+            });
+            var ChildComponent2 = React.createClass({
+                mixins: [FluxibleMixin],
+                componentDidMount: function(){
+                    childContext2 = this.getChildContext();
+                },
+                render: function () {
+                    var child = React.createFactory(ChildComponent1);
+                    return child();
+                }
+            });
+            var ParentComponent = React.createClass({
+                mixins: [FluxibleMixin],
+                statics: {
+                    storeListeners: [MockStore]
+                },
+                onChange: function () {
+                    done();
+                },
+                render: function () {
+                    var child = React.createFactory(ChildComponent2);
+                    return child();
+                }
+            });
+            var Element = React.createFactory(ParentComponent);
+            var component = ReactTestUtils.renderIntoDocument(Element({context: context}));
+            expect(childContext1).to.exist;
+            expect(childContext1.getStore).to.be.an('function');
+            expect(childContext1.executeAction).to.be.an('function');
+            expect(childContext2).to.exist;
+            expect(childContext2.getStore).to.be.an('function');
+            expect(childContext2.executeAction).to.be.an('function');
+            mockStore.emitChange();
+        });
+    });
+
     describe('componentDidMount', function () {
         it('should create an listeners array on start', function () {
             expect(FluxibleMixin.listeners).to.not.exist;


### PR DESCRIPTION
React.withContext is [deprecated in v0.13](https://github.com/facebook/react/blob/master/src/core/ReactContext.js#L54). This adds `getChildContext` to `FluxibleMixin` to help propagate the flux context to child components.