### PR TITLE
Use optional displayName action attribute in debug logs

### DIFF
--- a/lib/FluxibleContext.js
+++ b/lib/FluxibleContext.js
@@ -82,8 +82,9 @@ FluxContext.prototype.plug = function (plugin) {
 FluxContext.prototype.executeAction = function executeAction(action, payload, done) {
     var self = this;
     payload = payload || {};
+    var displayName = action.name || action.displayName;
     setImmediate(function executeActionImmediate() {
-        debug('Executing action ' + (action.name) + ' with payload', payload);
+        debug('Executing action ' + displayName + ' with payload', payload);
         action(self.getActionContext(), payload, done);
     });
 };

--- a/lib/FluxibleContext.js
+++ b/lib/FluxibleContext.js
@@ -82,7 +82,7 @@ FluxContext.prototype.plug = function (plugin) {
 FluxContext.prototype.executeAction = function executeAction(action, payload, done) {
     var self = this;
     payload = payload || {};
-    var displayName = action.name || action.displayName;
+    var displayName = action.displayName || action.name;
     setImmediate(function executeActionImmediate() {
         debug('Executing action ' + displayName + ' with payload', payload);
         action(self.getActionContext(), payload, done);


### PR DESCRIPTION
Currently `FluxibleContext` uses `debug` to log when actions are executed with `executeAction`. It uses [`Function.name`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name) to identify an action name to log. When code is minified, for example with UglifyJs's mangler, function names are removed and the log output contains an empty action name; `"Executing action  with payload"`. `Function.name` is read-only and so cannot forcibly be set outside of declaring a named function. 

This PR checks for an optional `displayName` property on action functions, which can be explicitly set, and is used in the log output if `name` is undefined.

```
// Declare named function - still useful.
function myAction(context, payload, done) {
    // Actiony stuffs
}

// Add displayName
myAction.displayName = 'myAction'
```

Existing behaviour should not be changed - if a `displayName` property is not the log output will still contain an empty name.

M