### PR TITLE
bind the component action handler to the context instance

### DIFF
--- a/lib/FluxibleContext.js
+++ b/lib/FluxibleContext.js
@@ -149,7 +149,7 @@ FluxContext.prototype.getComponentContext = function getComponentContext() {
         getStore: this._dispatcher.getStore.bind(this._dispatcher),
         // Prevents components from directly handling the callback for an action
         executeAction: function componentExecuteAction(action, payload) {
-            var actionHandler = self._app._componentActionHandler;
+            var actionHandler = self._app._componentActionHandler.bind(self);
             self.executeAction(action, payload, actionHandler);
         }
     };


### PR DESCRIPTION
We missed this in #58 yesterday.