### PR TITLE
[resolves #73] Remove requirement of using createFactory before passing ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ var App = React.createClass({
 
 // App
 var fluxibleApp = new Fluxible({
-    component: React.createFactory(App)
+    component: App
 });
 fluxibleApp.registerStore(Store);
 

--- a/docs/tutorials/routing.md
+++ b/docs/tutorials/routing.md
@@ -176,7 +176,7 @@ should be rendered.
 
 Let's make our original application component a little smarter. We'll include
 the `ApplicationStore` we just created. We also use the
-[`FluxibleMixin`](/api/fluxible.html), which adds convenient methods to interact
+[`FluxibleMixin`](../api/Fluxible.md), which adds convenient methods to interact
 with stores.
 
 File: `/components/Application.jsx`
@@ -186,7 +186,7 @@ var React = require('react');
 var ApplicationStore = require('../stores/ApplicationStore');
 var Home = require('./Home.jsx');
 var About = require('./About.jsx');
-var FluxibleMixin = require('fluxible').Mixin;
+var FluxibleMixin = require('fluxible').FluxibleMixin;
 
 var Application = React.createClass({
     mixins: [ FluxibleMixin ],
@@ -221,11 +221,10 @@ var Fluxible = require('fluxible');
 var routrPlugin = require('fluxible-plugin-routr');
 var routes = require('./configs/routes');
 var App = require('./components/Application.jsx');
-var Component = React.createFactory(App);
 var ApplicationStore = require('./stores/ApplicationStore');
 
 var app = new Fluxible({
-    component: Component
+    component: App
 });
 
 app.plug(routrPlugin({
@@ -267,12 +266,7 @@ server.use(function (req, res, next) {
             }
             return;
         }
-
-        var Component = app.getComponent();
-        var component = Component({
-            context: context.getComponentContext()
-        });
-        var html = React.renderToString(component);
+        var html = React.renderToString(context.createElement());
 
         res.send(html);
     });
@@ -369,7 +363,7 @@ var ApplicationStore = require('../stores/ApplicationStore');
 var Home = require('./Home.jsx');
 var About = require('./About.jsx');
 var Nav = require('./Nav.jsx');
-var FluxibleMixin = require('fluxible').Mixin;
+var FluxibleMixin = require('fluxible').FluxibleMixin;
 
 var Application = React.createClass({
     mixins: [ FluxibleMixin ],
@@ -427,11 +421,9 @@ var HtmlComponent = React.createFactory(require('./components/Html.jsx'));
 
 // ...
 
-    React.withContext(context.getComponentContext(), function () {
-        var html = React.renderToStaticMarkup(HtmlComponent({
-            markup: React.renderToString(Component())
-        }));
-    });
+    var html = React.renderToStaticMarkup(HtmlComponent({
+        markup: context.createElement()
+    }));
 
 // ...
 ```
@@ -495,14 +487,12 @@ server.use(function (req, res, next) {
         res.expose(app.dehydrate(context), 'App');
 
         var Component = app.getComponent();
-        React.withContext(context.getComponentContext(), function () {
-            var html = React.renderToStaticMarkup(HtmlComponent({
-                state: res.locals.state,
-                markup: React.renderToString(Component())
-            }));
+        var html = React.renderToStaticMarkup(HtmlComponent({
+            state: res.locals.state,
+            markup: React.renderToString(context.createElement())
+        }));
 
-            res.send(html);
-        });
+        res.send(html);
     });
 });
 ```
@@ -535,9 +525,7 @@ app.rehydrate(dehydratedState, function (err, context) {
     }
     var mountNode = document.getElementById('app');
 
-    React.withContext(context.getComponentContext(), function () {
-        React.render(app.getComponent()(), mountNode);
-    });
+    React.render(context.createElement(), mountNode);
 });
 ```
 
@@ -594,7 +582,7 @@ var About = require('./About.jsx');
 var Nav = require('./Nav.jsx');
 var ApplicationStore = require('../stores/ApplicationStore');
 var RouterMixin = require('flux-router-component').RouterMixin;
-var FluxibleMixin = require('fluxible').Mixin;
+var FluxibleMixin = require('fluxible').FluxibleMixin;
 
 var Application = React.createClass({
     mixins: [ RouterMixin, FluxibleMixin ],
@@ -641,7 +629,7 @@ In: `/components/Application.jsx`
 
 ```js
 var RouterMixin = require('flux-router-component').RouterMixin;
-var FluxibleMixin = require('fluxible').Mixin;
+var FluxibleMixin = require('fluxible').FluxibleMixin;
 
 var Application = React.createClass({
     mixins: [RouterMixin, FluxibleMixin],

--- a/lib/FluxibleContext.js
+++ b/lib/FluxibleContext.js
@@ -46,9 +46,16 @@ FluxContext.prototype.createElement = function createElement(props) {
     if (!Component) {
         throw new Error('A component was not specified.');
     }
+    var componentInstance;
+    if (!Component.hasOwnProperty('prototype')) {
+        // TODO: add warning to deprecate factories
+        componentInstance = Component(props);
+    } else {
+        componentInstance = React.createElement(Component, props);
+    }
     return FluxibleComponent({
         context: this.getComponentContext()
-    }, Component(props));
+    }, componentInstance);
 };
 
 /**

--- a/tests/unit/lib/FluxibleContext.js
+++ b/tests/unit/lib/FluxibleContext.js
@@ -20,7 +20,7 @@ describe('FluxibleContext', function () {
 
     describe('createElement', function () {
         it('should receive the correct props and context', function (done) {
-            var Component = React.createFactory(React.createClass({
+            var Component = React.createClass({
                 displayName: 'Component',
                 contextTypes: {
                     getStore: React.PropTypes.func.isRequired,
@@ -33,7 +33,7 @@ describe('FluxibleContext', function () {
                     done();
                 },
                 render: function () { return null; }
-            }));
+            });
             var app = new Fluxible({
                 component: Component
             });

--- a/tests/unit/lib/FluxibleContext.js
+++ b/tests/unit/lib/FluxibleContext.js
@@ -41,6 +41,28 @@ describe('FluxibleContext', function () {
 
             React.renderToString(context.createElement({foo: 'bar'}));
         });
+        it('should receive the correct props and context if passed factory', function (done) {
+            var Component = React.createFactory(React.createClass({
+                displayName: 'Component',
+                contextTypes: {
+                    getStore: React.PropTypes.func.isRequired,
+                    executeAction: React.PropTypes.func.isRequired
+                },
+                componentWillMount: function () {
+                    expect(this.props.foo).to.equal('bar');
+                    expect(this.context.getStore).to.be.a('function');
+                    expect(this.context.executeAction).to.be.a('function');
+                    done();
+                },
+                render: function () { return null; }
+            }));
+            var app = new Fluxible({
+                component: Component
+            });
+            context = app.createContext();
+
+            React.renderToString(context.createElement({foo: 'bar'}));
+        });
     });
 
     describe('actionContext', function () {


### PR DESCRIPTION
...component to Fluxible instance

Next minor can probably deprecate passing a factory in since it will not be need when we use `React.createElement()`