### PR TITLE
Update to dispatchr@0.3.x and change test utils to use new-less API

### DIFF
--- a/addons/BaseStore.js
+++ b/addons/BaseStore.js
@@ -1,1 +1,1 @@
-module.exports = require('dispatchr/utils/BaseStore');
+module.exports = require('dispatchr/addons/BaseStore');

--- a/addons/createStore.js
+++ b/addons/createStore.js
@@ -1,1 +1,1 @@
-module.exports = require('dispatchr/utils/createStore');
+module.exports = require('dispatchr/addons/createStore');

--- a/docs/api/Actions.md
+++ b/docs/api/Actions.md
@@ -103,21 +103,29 @@ Retrieve a store instance by constructor. Useful for reading from the store. Sho
 
 ## Testing
 
-When testing your actions, you can use our `MockActionContext` library and pass an instance to your action to record the methods that the action calls on the context.
+When testing your actions, you can use our `createMockActionContext` library and pass an instance to your action to record the methods that the action calls on the context.
 
 When `dispatch` is called, it will push an object to the `dispatchCalls` array. Each object contains a `name` and `payload` key.
 
 When `executeAction` is called, it will push an object to the `executeActionCalls` array. Each object contains an `action` and `payload` key.
 
-`getStore` calls will be proxied to a dispatcher instance, which you can register stores to via `MockActionContext.registerStore(MockStore)`.
+`getStore` calls will be proxied to a dispatcher instance, which you can register stores to upon instantiation:
+ 
+```js
+createMockActionContext({ stores: [MockStore] });`
+```
 
 ### Usage
 
 Here is an example mocha test that display using each of `ActionContext` methods being tested:
 
 ```js
+<<<<<<< HEAD
 import utils from 'fluxible/utils';
 let MockActionContext = utils.createMockActionContext();
+=======
+var createMockActionContext = require('fluxible/utils').createMockActionContext;
+>>>>>>> [resolves #95] Update to dispatchr@0.3.x and change test utils to use new-less API
 
 // Real store, overridden with MockStore in test
 import {BaseStore} from 'fluxible/addons';
@@ -137,7 +145,7 @@ let otherAction = function (actionContext, payload, done) {
     done();
 };
 
-// Register the mock FooStore
+// the mock FooStore
 class MockFooStore extends BaseStore {
     constructor (dispatcher) {
         super(dispatcher);
@@ -155,7 +163,6 @@ MockFooStore.storeName = 'FooStore'; // Matches FooStore.storeName
 MockFooStore.handlers = {
     'FOO': 'handleFoo'
 };
-MockActionContext.registerStore(MockFooStore);
 
 // Tests
 describe('myAction', function () {
@@ -163,7 +170,9 @@ describe('myAction', function () {
     let actionContext;
 
     beforeEach(function () {
-        actionContext = new MockActionContext();
+        actionContext = createMockActionContext({
+            stores: [FooStore]
+        });
     });
 
     it('should dispatch foo', function (done) {

--- a/docs/api/Components.md
+++ b/docs/api/Components.md
@@ -115,15 +115,18 @@ When testing your components, you can use our `MockComponentContext` library and
 
 When `executeAction` is called, it will push an object to the `executeActionCalls` array. Each object contains an `action` and `payload` key.
 
-`getStore` calls will be proxied to a dispatcher instance, which you can register stores to via `MockActionContext.registerStore(MockStore)`.
+`getStore` calls will be proxied to a dispatcher instance, which you can register stores to upon instantiation:
+
+```js
+createMockComponentContext({ stores: [MockStore] });`
+```
 
 ### Usage
 
 Here is an example component test that uses `React.TestUtils` to render the component into `jsdom` to test the store integration.
 
 ```js
-import utils from 'fluxible/utils';
-let MockComponentContext = utils.createMockComponentContext();
+import createMockComponentContext from 'fluxible/utils';
 
 // Real store, overridden with MockStore in test
 import {BaseStore} from 'fluxible/addons';
@@ -139,7 +142,7 @@ let myAction = function (actionContext, payload, done) {
     done();
 };
 
-// Register the mock FooStore
+// the mock FooStore
 class MockFooStore extends BaseStore {
     constructor (dispatcher) {
         super(dispatcher);
@@ -157,7 +160,6 @@ MockFooStore.storeName = 'FooStore'; // Matches FooStore.storeName
 MockFooStore.handlers = {
     'FOO': 'handleFoo'
 };
-MockActionContext.registerStore(MockFooStore);
 
 describe('TestComponent', function () {
     var jsdom = require('jsdom');
@@ -169,7 +171,9 @@ describe('TestComponent', function () {
     var TestComponent;
 
     beforeEach(function (done) {
-        componentContext = new MockComponentContext();
+        componentContext = createMockComponentContext({
+            stores: [FooStore]
+        });
         jsdom.env('<html><body></body></html>', [], function (err, window) {
             global.window = window;
             global.document = window.document;

--- a/lib/Fluxible.js
+++ b/lib/Fluxible.js
@@ -7,7 +7,7 @@
 var debug = require('debug')('Fluxible');
 var async = require('async');
 var FluxibleContext = require('./FluxibleContext');
-var dispatcherClassFactory = require('dispatchr');
+var dispatchr = require('dispatchr');
 var React = require('react');
 
 /**
@@ -43,7 +43,7 @@ function Fluxible(options) {
     }
 
     // Initialize dependencies
-    this._dispatcherClass = dispatcherClassFactory();
+    this._dispatcher = dispatchr.createDispatcher();
 }
 
 /**
@@ -88,11 +88,11 @@ Fluxible.prototype._defaultComponentActionHandler = function defaultComponentAct
  * Creates a new dispatcher instance using the application's dispatchr class. Used by
  * FluxibleContext to create new dispatcher instance
  * @method createDispatcherInstance
- * @param {Object} context The context object to be provided to each store instance
+ * @param {Object} contextOptions The context options to be provided to each store instance
  * @returns {Dispatcher}
  */
-Fluxible.prototype.createDispatcherInstance = function createDispatcherInstance(context) {
-    return new (this._dispatcherClass)(context);
+Fluxible.prototype.createDispatcherInstance = function createDispatcherInstance(contextOptions) {
+    return this._dispatcher.createContext(contextOptions);
 };
 
 /**
@@ -155,7 +155,7 @@ Fluxible.prototype.getAppComponent = function getAppComponent() {
  */
 Fluxible.prototype.registerStore = function registerStore() {
     debug(arguments[0].storeName + ' store registered');
-    this._dispatcherClass.registerStore.apply(this._dispatcherClass, arguments);
+    this._dispatcher.registerStore.apply(this._dispatcher, arguments);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "debug": "^2.0.0",
-    "dispatchr": "^0.2.5",
+    "dispatchr": "^0.3.1",
     "es6-promise": "^2.0.1",
     "is-promise": "^2.0.0",
     "object-assign": "^2.0.0",

--- a/tests/unit/lib/Fluxible.js
+++ b/tests/unit/lib/Fluxible.js
@@ -39,7 +39,7 @@ describe('Fluxible', function () {
     describe('#registerStore', function () {
         it('should register the new store', function () {
             app.registerStore(FooStore);
-            expect(app._dispatcherClass.isRegistered(FooStore)).to.equal(true);
+            expect(app._dispatcher.isRegistered(FooStore)).to.equal(true);
         });
     });
 

--- a/tests/unit/lib/FluxibleMixin.js
+++ b/tests/unit/lib/FluxibleMixin.js
@@ -5,18 +5,15 @@ var expect = require('chai').expect,
     React = require('react/addons'),
     ReactTestUtils = require('react/lib/ReactTestUtils'),
     FluxibleMixin = require('../../../').FluxibleMixin,
-    createStore = require('dispatchr/utils/createStore'),
+    createStore = require('dispatchr/addons/createStore'),
     MockStore = createStore({
         storeName: 'MockStore'
     }),
     MockStore2 = createStore({
         storeName: 'MockStore2'
     }),
-    MockContext = require('../../../utils/MockComponentContext')(),
+    createMockComponentContext = require('../../../utils/createMockComponentContext'),
     jsdom = require('jsdom');
-
-MockContext.Dispatcher.registerStore(MockStore);
-MockContext.Dispatcher.registerStore(MockStore2);
 
 describe('StoreListenerMixin', function () {
     var context,
@@ -24,7 +21,9 @@ describe('StoreListenerMixin', function () {
         mockStore2;
 
     beforeEach(function (done) {
-        context = new MockContext();
+        context = createMockComponentContext({
+            stores: [MockStore, MockStore2]
+        });
         mockStore = context.getStore(MockStore);
         mockStore2 = context.getStore(MockStore2);
         jsdom.env('<html><body></body></html>', [], function (err, window) {

--- a/tests/unit/utils/createMockComponentContext.js
+++ b/tests/unit/utils/createMockComponentContext.js
@@ -3,60 +3,26 @@
 
 'use strict';
 
-var ROOT_DIR = require('path').resolve(__dirname + '/../../..');
-
 var expect = require('chai').expect;
 var mockery = require('mockery');
+var createMockComponentContext = require('../../../utils').createMockComponentContext;
 
-describe('MockComponentContext', function () {
-    var ComponentContext;
-
-    function dispatchr () {}
-    dispatchr.prototype.getStore = function () {};
-
-    function MockActionContext () {}
-
-    before(function () {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-
-        mockery.registerMock('dispatchr', function () {
-            return dispatchr;
-        });
-
-        mockery.registerMock('./MockActionContext', function () {
-                return MockActionContext;
-            }
-        );
-
-        ComponentContext = require(ROOT_DIR + '/utils/MockComponentContext')();
-    });
-
-    it('should be a constructor', function () {
-        expect(new ComponentContext()).to.be.an.instanceof(ComponentContext);
-    });
-
-    it('should have a Dispatcher property that is a dispatchr constructor', function() {
-        expect(ComponentContext).to.have.property('Dispatcher', dispatchr);
-    });
+describe('createMockComponentContext', function () {
 
     describe('instance', function () {
         var context;
 
         before(function () {
-            context = new ComponentContext();
+            context = createMockComponentContext();
         });
 
         it('should have the following properties: dispatcher, executeActionCalls', function () {
-            expect(context).to.have.property('dispatcher').that.is.an.instanceof(dispatchr);
             expect(context).to.have.property('executeActionCalls').that.is.an('array').and.empty;
         });
 
         describe('#getStore', function () {
             it('should delegate to the dispatcher getStore method', function () {
-                expect(context).to.have.property('getStore', dispatchr.getStore);
+                expect(context).to.have.property('getStore');
             });
         });
 
@@ -72,7 +38,9 @@ describe('MockComponentContext', function () {
                 };
 
                 function mockAction (ctx, payload, done) {
-                    expect(ctx).to.be.an.instanceof(MockActionContext);
+                    expect(ctx).to.be.an('object');
+                    expect(ctx.dispatch).to.be.a('function');
+                    expect(ctx.executeAction).to.be.a('function');
                     expect(payload).to.equal(mockPayload);
                     done();
                 }

--- a/utils/BaseStore.js
+++ b/utils/BaseStore.js
@@ -1,3 +1,0 @@
-console.warn("require('fluxible/utils/createStore') is deprecated. Please use " +
-"require('fluxible/addons').BaseStore or require('fluxible/addons/createStore').");
-module.exports = require('../addons/BaseStore');

--- a/utils/MockActionContext.js
+++ b/utils/MockActionContext.js
@@ -4,41 +4,6 @@
  */
 'use strict';
 
-var dispatchr = require('dispatchr');
-
-module.exports = function createMockActionContext(Dispatcher) {
-    var Dispatcher = Dispatcher || dispatchr();
-
-    function MockActionContext (dispatcher) {
-        this.Dispatcher = Dispatcher;
-        this.dispatcher = dispatcher || new Dispatcher();
-        this.executeActionCalls = [];
-        this.dispatchCalls = [];
-    }
-
-    MockActionContext.registerStore = Dispatcher.registerStore;
-
-    MockActionContext.prototype.getStore = function (name) {
-        return this.dispatcher.getStore(name);
-    };
-
-    MockActionContext.prototype.dispatch = function (name, payload) {
-        this.dispatchCalls.push({
-            name: name,
-            payload: payload
-        });
-        this.dispatcher.dispatch(name, payload);
-    };
-
-    MockActionContext.prototype.executeAction = function (action, payload, callback) {
-        this.executeActionCalls.push({
-            action: action,
-            payload: payload
-        });
-        action(this, payload, callback);
-    };
-
-    MockActionContext.Dispatcher = Dispatcher;
-
-    return MockActionContext;
-};
+throw new Error("`require('fluxible/utils/MockActionContext')` has been removed in " +
+    "favor of `require('fluxible/utils').createMockActionContext; See " +
+    "https://github.com/yahoo/fluxible/pulls/99 for details.`");

--- a/utils/MockComponentContext.js
+++ b/utils/MockComponentContext.js
@@ -4,35 +4,6 @@
  */
 'use strict';
 
-var dispatchr = require('dispatchr');
-var createMockActionContext = require('./MockActionContext');
-function noop () {}
-
-module.exports = function createMockComponentContextClass(Dispatcher) {
-    Dispatcher = Dispatcher || dispatchr();
-    var MockActionContext = createMockActionContext(Dispatcher);
-
-    function MockComponentContext () {
-        this.dispatcher = new Dispatcher();
-        this.executeActionCalls = [];
-        this.getStore = this.getStore.bind(this);
-        this.executeAction = this.executeAction.bind(this);
-    }
-
-    MockComponentContext.prototype.getStore = function (name) {
-        return this.dispatcher.getStore(name);
-    };
-
-    MockComponentContext.prototype.executeAction = function (action, payload) {
-        this.executeActionCalls.push({
-            action: action,
-            payload: payload
-        });
-        action(new MockActionContext(this.dispatcher), payload, noop);
-    };
-
-    MockComponentContext.Dispatcher = Dispatcher;
-    MockComponentContext.registerStore = Dispatcher.registerStore;
-
-    return MockComponentContext;
-};
+throw new Error("`require('fluxible/utils/MockComponentContext')` has been removed in " +
+    "favor of `require('fluxible/utils').createMockComponentContext; See " +
+    "https://github.com/yahoo/fluxible/pulls/99 for details.`");

--- a/utils/createMockActionContext.js
+++ b/utils/createMockActionContext.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2014, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+'use strict';
+
+var dispatchr = require('dispatchr');
+
+function MockActionContext (dispatcherContext) {
+    this.dispatcherContext = dispatcherContext;
+    this.executeActionCalls = [];
+    this.dispatchCalls = [];
+}
+
+MockActionContext.prototype.getStore = function (name) {
+    return this.dispatcherContext.getStore(name);
+};
+
+MockActionContext.prototype.dispatch = function (name, payload) {
+    this.dispatchCalls.push({
+        name: name,
+        payload: payload
+    });
+    this.dispatcherContext.dispatch(name, payload);
+};
+
+MockActionContext.prototype.executeAction = function (action, payload, callback) {
+    this.executeActionCalls.push({
+        action: action,
+        payload: payload
+    });
+    action(this, payload, callback);
+};
+
+module.exports = function createMockActionContext(options) {
+    options = options || {};
+    options.stores = options.stores || [];
+    options.dispatcher = options.dispatcher || dispatchr.createDispatcher({
+        stores: options.stores
+    });
+    options.dispatcherContext = options.dispatcherContext || options.dispatcher.createContext();
+
+    return new MockActionContext(options.dispatcherContext);
+};

--- a/utils/createMockComponentContext.js
+++ b/utils/createMockComponentContext.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2014, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+'use strict';
+
+var dispatchr = require('dispatchr');
+var createMockActionContext = require('./createMockActionContext');
+function noop () {}
+
+function MockComponentContext (dispatcherContext) {
+    this.dispatcherContext = dispatcherContext;
+    this.executeActionCalls = [];
+    this.getStore = this.getStore.bind(this);
+    this.executeAction = this.executeAction.bind(this);
+}
+
+MockComponentContext.prototype.getStore = function (name) {
+    return this.dispatcherContext.getStore(name);
+};
+
+MockComponentContext.prototype.executeAction = function (action, payload) {
+    this.executeActionCalls.push({
+        action: action,
+        payload: payload
+    });
+    action(createMockActionContext({
+        dispatcherContext: this.dispatcherContext
+    }), payload, noop);
+};
+
+module.exports = function createMockComponentContext(options) {
+    options = options || {};
+    options.stores = options.stores || [];
+    options.dispatcher = options.dispatcher || dispatchr.createDispatcher({
+        stores: options.stores
+    });
+    options.dispatcherContext = options.dispatcherContext || options.dispatcher.createContext();
+
+    return new MockComponentContext(options.dispatcherContext);
+};

--- a/utils/createStore.js
+++ b/utils/createStore.js
@@ -1,3 +1,0 @@
-console.warn("require('fluxible/utils/createStore') is deprecated. Please use " +
-"require('fluxible/addons').BaseStore or require('fluxible/addons/createStore').");
-module.exports = require('../addons/createStore');

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,4 +1,4 @@
 module.exports = {
-    createMockActionContext: require('./MockActionContext'),
-    createMockComponentContext: require('./MockComponentContext')
+    createMockActionContext: require('./createMockActionContext'),
+    createMockComponentContext: require('./createMockComponentContext')
 };


### PR DESCRIPTION
You can see the new test utils APIs in the doc updates.

```js
var MockComponentContext = require('fluxible/utils/MockComponentContext')();
MockComponentContext.registerStore(FooStore);
var context = new MockComponentContext();
```

becomes

```js
var createMockComponentContext = require('fluxible/utils').createMockComponentContext;
var context = createMockComponentContext({
    stores: [FooStore]
});
```