### PR TITLE
FluxibleContext.executeAction() returns the promise now

### DIFF
--- a/lib/FluxibleContext.js
+++ b/lib/FluxibleContext.js
@@ -189,7 +189,7 @@ FluxContext.prototype.getComponentContext = function getComponentContext() {
         getStore: this._dispatcher.getStore.bind(this._dispatcher),
         // Prevents components from directly handling the callback for an action
         executeAction: function componentExecuteAction(action, payload) {
-            self.executeAction(action, payload).catch(function actionHandlerWrapper(err) {
+            return self.executeAction(action, payload).catch(function actionHandlerWrapper(err) {
                 var noop = function () {};
                 self.executeAction(self._app._componentActionHandler, { err: err }, noop);
             });


### PR DESCRIPTION
If you have an action that should return a promise it is essentiell that
FluxibleContext.executeAction() returns your promise. Thats the fix.