### PR TITLE
[wip] initial attempt to namespace plugins

### DIFF
--- a/lib/Fluxible.js
+++ b/lib/Fluxible.js
@@ -8,7 +8,6 @@ var debug = require('debug')('Fluxible');
 var async = require('async');
 var FluxibleContext = require('./FluxibleContext');
 var dispatchr = require('dispatchr');
-var React = require('react');
 
 /**
  * Provides a structured way of registering an application's configuration and
@@ -34,7 +33,14 @@ function Fluxible(options) {
     // Options
     this._component = options.component;
     this._componentActionHandler = options.componentActionHandler || this._defaultComponentActionHandler;
-    this._plugins = [];
+    this._plugins = {};
+
+    if (options.plugins) {
+        var self = this;
+        options.plugins.forEach(function initRegisterPlugins(plugin) {
+            self.plug(plugin);
+        });
+    }
 
     if (!this._component.hasOwnProperty('prototype')) {
         console.warn('It is no longer necessary to wrap your component with ' +
@@ -59,10 +65,11 @@ Fluxible.prototype.createContext = function createContext(options) {
     var context = new FluxibleContext(options);
 
     // Plug context with app plugins that implement plugContext method
-    this._plugins.forEach(function eachPlugin(plugin) {
+    Object.keys(this._plugins).forEach(function eachPlugin(name) {
+        var plugin = self._plugins[name];
         if (plugin.plugContext) {
             var contextPlugin = plugin.plugContext(options, context, self);
-            contextPlugin.name = contextPlugin.name || plugin.name;
+            contextPlugin.name = contextPlugin.name || name;
             context.plug(contextPlugin);
         }
     });
@@ -111,7 +118,10 @@ Fluxible.prototype.plug = function (plugin) {
     if (!plugin.name) {
         throw new Error('Application plugin must have a name');
     }
-    this._plugins.push(plugin);
+    if (this._plugins[plugin.name]) {
+        throw new Error('A plugin with that name is already registered');
+    }
+    this._plugins[plugin.name] = plugin;
 };
 
 /**
@@ -121,13 +131,7 @@ Fluxible.prototype.plug = function (plugin) {
  * @returns {Object}
  */
 Fluxible.prototype.getPlugin = function (pluginName) {
-    var plugin = null;
-    this._plugins.forEach(function (p) {
-        if (pluginName === p.name) {
-            plugin = p;
-        }
-    });
-    return plugin;
+    return this._plugins[pluginName];
 };
 
 /**
@@ -162,10 +166,11 @@ Fluxible.prototype.dehydrate = function dehydrate(context) {
         plugins: {}
     };
 
-    this._plugins.forEach(function (plugin) {
+    Object.keys(this._plugins).forEach(function (name) {
+        var plugin = self._plugins[name];
         if ('function' === typeof plugin.dehydrate) {
             // Use a namespace for storing plugin state and provide access to the application
-            state.plugins[plugin.name] = plugin.dehydrate(self);
+            state.plugins[name] = plugin.dehydrate(self);
         }
     });
 
@@ -185,15 +190,16 @@ Fluxible.prototype.rehydrate = function rehydrate(obj, callback) {
     debug('rehydrate', obj);
     var self = this;
     obj.plugins = obj.plugins || {};
-    var pluginTasks = this._plugins.filter(function (plugin) {
-        return 'function' === typeof plugin.rehydrate;
-    }).map(function (plugin) {
+    var pluginTasks = Object.keys(self._plugins).filter(function (name) {
+        return 'function' === typeof self._plugins[name].rehydrate;
+    }).map(function (name) {
+        var plugin = self._plugins[name];
         return function (asyncCallback) {
             if (2 === plugin.rehydrate.length) { // Async plugin
-                plugin.rehydrate(obj.plugins[plugin.name], asyncCallback);
+                plugin.rehydrate(obj.plugins[name], asyncCallback);
             } else { // Sync plugin
                 try {
-                    plugin.rehydrate(obj.plugins[plugin.name]);
+                    plugin.rehydrate(obj.plugins[name]);
                 } catch (e) {
                     asyncCallback(e);
                     return;

--- a/lib/FluxibleContext.js
+++ b/lib/FluxibleContext.js
@@ -29,7 +29,7 @@ function FluxContext(options) {
     this._dispatcher = null;
 
     // Plugins
-    this._plugins = [];
+    this._plugins = {};
 
     // Set up contexts
     this._actionContext = null;
@@ -80,7 +80,10 @@ FluxContext.prototype.plug = function (plugin) {
     if (!plugin.name) {
         throw new Error('Context plugin must have a name');
     }
-    this._plugins.push(plugin);
+    if (this._plugins[plugin.name]) {
+        throw new Error('A plugin with that name is already registered');
+    }
+    this._plugins[plugin.name] = plugin;
 };
 
 /**
@@ -159,10 +162,12 @@ FluxContext.prototype.getActionContext = function getActionContext() {
         getStore: this._dispatcher.getStore.bind(this._dispatcher)
     };
 
-    self._plugins.forEach(function pluginsEach(plugin) {
-        var actionContextPlugin = plugin.plugActionContext;
+    Object.keys(this._plugins).forEach(function (name) {
+        var actionContextPlugin = self._plugins[name].plugActionContext;
         if (actionContextPlugin) {
-            actionContextPlugin(actionContext, self, self._app);
+            var pluginActionContext = {};
+            actionContextPlugin(pluginActionContext, self, self._app);
+            actionContext[name] = pluginActionContext;
         }
     });
 
@@ -196,10 +201,12 @@ FluxContext.prototype.getComponentContext = function getComponentContext() {
         }
     };
 
-    self._plugins.forEach(function pluginsEach(plugin) {
-        var componentPlugin = plugin.plugComponentContext;
+    Object.keys(this._plugins).forEach(function pluginsEach(name) {
+        var componentPlugin = self._plugins[name].plugComponentContext;
         if (componentPlugin) {
-            componentPlugin(componentContext, self, self._app);
+            var pluginComponentContext = {};
+            componentPlugin(pluginComponentContext, self, self._app);
+            componentContext[name] = pluginComponentContext;
         }
     });
 
@@ -219,10 +226,12 @@ FluxContext.prototype.getStoreContext = function getStoreContext() {
     var self = this;
     var storeContext = {};
 
-    self._plugins.forEach(function pluginsEach(plugin) {
-        var storeContextPlugin = plugin.plugStoreContext;
+    Object.keys(this._plugins).forEach(function pluginsEach(name) {
+        var storeContextPlugin = self._plugins[name].plugStoreContext;
         if (storeContextPlugin) {
-            storeContextPlugin(storeContext, self, self._app);
+            var pluginStoreContext = {};
+            storeContextPlugin(pluginStoreContext, self, self._app);
+            storeContext[name] = pluginStoreContext;
         }
     });
 
@@ -242,10 +251,11 @@ FluxContext.prototype.dehydrate = function dehydrate() {
         plugins: {}
     };
 
-    self._plugins.forEach(function pluginsEach(plugin) {
+    Object.keys(this._plugins).forEach(function pluginsEach(name) {
+        var plugin = self._plugins[name];
         if ('function' === typeof plugin.dehydrate) {
             // Use a namespace for storing plugin state and provide access to the application
-            state.plugins[plugin.name] = plugin.dehydrate(self);
+            state.plugins[name] = plugin.dehydrate(self);
         }
     });
 
@@ -262,15 +272,16 @@ FluxContext.prototype.dehydrate = function dehydrate() {
 FluxContext.prototype.rehydrate = function rehydrate(obj, callback) {
     var self = this;
     obj.plugins = obj.plugins || {};
-    var pluginTasks = this._plugins.filter(function (plugin) {
-        return 'function' === typeof plugin.rehydrate;
-    }).map(function (plugin) {
+    var pluginTasks = Object.keys(this._plugins).filter(function (name) {
+        return 'function' === typeof self._plugins[name].rehydrate;
+    }).map(function (name) {
+        var plugin = self._plugins[name];
         return function (asyncCallback) {
             if (2 === plugin.rehydrate.length) { // Async plugin
-                plugin.rehydrate(obj.plugins[plugin.name], asyncCallback);
+                plugin.rehydrate(obj.plugins[name], asyncCallback);
             } else { // Sync plugin
                 try {
-                    plugin.rehydrate(obj.plugins[plugin.name]);
+                    plugin.rehydrate(obj.plugins[name]);
                 } catch (e) {
                     asyncCallback(e);
                     return;

--- a/tests/unit/lib/Fluxible.js
+++ b/tests/unit/lib/Fluxible.js
@@ -1,11 +1,10 @@
 /*globals describe,it,beforeEach */
-"use strict";
+'use strict';
 require('node-jsx').install({ extension: '.jsx' });
 
 // Fix for https://github.com/joyent/node/issues/8648
 global.Promise = require('es6-promise').Promise;
 
-var path = require('path');
 var expect = require('chai').expect;
 var Component = require('../../fixtures/applications/basic/components/Application.jsx');
 var Fluxible = require('../../../');
@@ -62,11 +61,12 @@ describe('Fluxible', function () {
     });
 
     describe('plugins', function () {
-        var testPlugin = require('../../fixtures/plugins/TestApplicationPlugin'),
-            testPluginSync = require('../../fixtures/plugins/TestApplicationPluginSync'),
-            pluginInstance,
-            foo = 'bar',
-            context;
+        var testPlugin = require('../../fixtures/plugins/TestApplicationPlugin');
+        var testPluginSync = require('../../fixtures/plugins/TestApplicationPluginSync');
+        var pluginInstance;
+        var foo = 'bar';
+        var context;
+
         beforeEach(function () {
             pluginInstance = testPlugin(foo);
             app.plug(pluginInstance);
@@ -77,26 +77,34 @@ describe('Fluxible', function () {
                 app.plug({});
             }).to.throw();
         });
+        it('should throw if a plugin is already registerd by that name', function () {
+            expect(function () {
+                app.plug({ name: 'TestAppPlugin' });
+            }).to.throw();
+        });
         it('should provide access to the plugin instance', function () {
             expect(app.getPlugin(pluginInstance.name)).to.equal(pluginInstance);
         });
         it('should add the getFoo function to the action context', function () {
             var actionContext = context.getActionContext();
             expect(actionContext).to.be.an('object');
-            expect(actionContext.getFoo).to.be.a('function');
-            expect(actionContext.getFoo()).to.equal(foo);
+            expect(actionContext.TestAppPlugin).to.be.an('object');
+            expect(actionContext.TestAppPlugin.getFoo).to.be.a('function');
+            expect(actionContext.TestAppPlugin.getFoo()).to.equal(foo);
         });
         it('should add the getDimensions function to the component context', function () {
             var componentContext = context.getComponentContext();
             expect(componentContext).to.be.an('object');
-            expect(componentContext.getFoo).to.be.a('function');
-            expect(componentContext.getFoo()).to.equal(foo);
+            expect(componentContext.TestAppPlugin).to.be.an('object');
+            expect(componentContext.TestAppPlugin.getFoo).to.be.a('function');
+            expect(componentContext.TestAppPlugin.getFoo()).to.equal(foo);
         });
         it('should add the getDimensions function to the store context', function () {
             var storeContext = context.getStoreContext();
             expect(storeContext).to.be.an('object');
-            expect(storeContext.getFoo).to.be.a('function');
-            expect(storeContext.getFoo()).to.equal(foo);
+            expect(storeContext.TestAppPlugin).to.be.an('object');
+            expect(storeContext.TestAppPlugin.getFoo).to.be.a('function');
+            expect(storeContext.TestAppPlugin.getFoo()).to.equal(foo);
         });
         it('should dehydrate and rehydrate the async plugin correctly', function (done) {
             // Create a copy of the state
@@ -117,9 +125,9 @@ describe('Fluxible', function () {
                     done(err);
                     return;
                 }
-                expect(newContext.getActionContext().getFoo()).to.equal(foo);
-                expect(newContext.getComponentContext().getFoo()).to.equal(foo);
-                expect(newContext.getStoreContext().getFoo()).to.equal(foo);
+                expect(newContext.getActionContext().TestAppPlugin.getFoo()).to.equal(foo);
+                expect(newContext.getComponentContext().TestAppPlugin.getFoo()).to.equal(foo);
+                expect(newContext.getStoreContext().TestAppPlugin.getFoo()).to.equal(foo);
                 done();
             });
         });
@@ -142,9 +150,9 @@ describe('Fluxible', function () {
                     done(err);
                     return;
                 }
-                expect(newContext.getActionContext().getFoo()).to.equal(foo);
-                expect(newContext.getComponentContext().getFoo()).to.equal(foo);
-                expect(newContext.getStoreContext().getFoo()).to.equal(foo);
+                expect(newContext.getActionContext().TestAppPlugin.getFoo()).to.equal(foo);
+                expect(newContext.getComponentContext().TestAppPlugin.getFoo()).to.equal(foo);
+                expect(newContext.getStoreContext().TestAppPlugin.getFoo()).to.equal(foo);
                 done();
             });
         });

--- a/tests/unit/lib/FluxibleContext.js
+++ b/tests/unit/lib/FluxibleContext.js
@@ -249,7 +249,7 @@ describe('FluxibleContext', function () {
                 actionContext.executeAction(action, payload, function () {
                     expect(actionCalls[0].payload).to.equal(false);
                     done();
-                })
+                });
             });
         });
     });
@@ -335,23 +335,31 @@ describe('FluxibleContext', function () {
                 context.plug({});
             }).to.throw();
         });
+        it('should throw if a plugin is already registerd by that name', function () {
+            expect(function () {
+                context.plug({ name: 'DimensionsPlugin' });
+            }).to.throw();
+        });
         it('should add the getDimensions function to the action context', function () {
             var actionContext = context.getActionContext();
             expect(actionContext).to.be.an('object');
-            expect(actionContext.getDimensions).to.be.a('function');
-            expect(actionContext.getDimensions()).to.deep.equal(dimensions);
+            expect(actionContext.DimensionsPlugin).to.be.an('object');
+            expect(actionContext.DimensionsPlugin.getDimensions).to.be.a('function');
+            expect(actionContext.DimensionsPlugin.getDimensions()).to.deep.equal(dimensions);
         });
         it('should add the getDimensions function to the component context', function () {
             var componentContext = context.getComponentContext();
             expect(componentContext).to.be.an('object');
-            expect(componentContext.getDimensions).to.be.a('function');
-            expect(componentContext.getDimensions()).to.deep.equal(dimensions);
+            expect(componentContext.DimensionsPlugin).to.be.an('object');
+            expect(componentContext.DimensionsPlugin.getDimensions).to.be.a('function');
+            expect(componentContext.DimensionsPlugin.getDimensions()).to.deep.equal(dimensions);
         });
         it('should add the getDimensions function to the store context', function () {
             var storeContext = context.getStoreContext();
             expect(storeContext).to.be.an('object');
-            expect(storeContext.getDimensions).to.be.a('function');
-            expect(storeContext.getDimensions()).to.deep.equal(dimensions);
+            expect(storeContext.DimensionsPlugin).to.be.an('object');
+            expect(storeContext.DimensionsPlugin.getDimensions).to.be.a('function');
+            expect(storeContext.DimensionsPlugin.getDimensions()).to.deep.equal(dimensions);
         });
         it('should dehydrate and rehydrate the async plugin correctly', function (done) {
             // Create a copy of the state
@@ -367,9 +375,9 @@ describe('FluxibleContext', function () {
                 if (err) {
                     done(err);
                 }
-                expect(newContext.getActionContext().getDimensions()).to.deep.equal(dimensions);
-                expect(newContext.getComponentContext().getDimensions()).to.deep.equal(dimensions);
-                expect(newContext.getStoreContext().getDimensions()).to.deep.equal(dimensions);
+                expect(newContext.getActionContext().DimensionsPlugin.getDimensions()).to.deep.equal(dimensions);
+                expect(newContext.getComponentContext().DimensionsPlugin.getDimensions()).to.deep.equal(dimensions);
+                expect(newContext.getStoreContext().DimensionsPlugin.getDimensions()).to.deep.equal(dimensions);
                 done();
             });
         });
@@ -387,9 +395,9 @@ describe('FluxibleContext', function () {
                 if (err) {
                     done(err);
                 }
-                expect(newContext.getActionContext().getDimensions()).to.deep.equal(dimensions);
-                expect(newContext.getComponentContext().getDimensions()).to.deep.equal(dimensions);
-                expect(newContext.getStoreContext().getDimensions()).to.deep.equal(dimensions);
+                expect(newContext.getActionContext().DimensionsPlugin.getDimensions()).to.deep.equal(dimensions);
+                expect(newContext.getComponentContext().DimensionsPlugin.getDimensions()).to.deep.equal(dimensions);
+                expect(newContext.getStoreContext().DimensionsPlugin.getDimensions()).to.deep.equal(dimensions);
                 done();
             });
         });


### PR DESCRIPTION
This is my initial attempt to namespace plugins and address #79.

One goal I had was to ensure that plugin authors don't need to change anything. However when we used to pass the context to a plugin's `plugActionContext`, `plugComponentContext` or `plugStoreContext`, it may have already been decorated with some resources.

For example in the `getActionContext` method we were creating this context object:

```js
var actionContext = {
    dispatch: this._dispatcher.dispatch.bind(this._dispatcher),
    executeAction: this.executeAction.bind(this),
    getStore: this._dispatcher.getStore.bind(this._dispatcher)
};
```

and passing that to the plugin's `plugActionContext` function, which it then decoratea with it's own functionality. But now we're passing an empty object `{}` just for that plugin to decorate. My concern is... what if plugin authors were using the resources on the context we were passing.

If the plugins do indeed need those resources:

 - We could include copies of the decorated resources (`dispatch`, `executeAction` and `getStore` in the example above) to each plugin. No changes are required for plugin authors _but_ it feels sloppy to have multiple references to these resources floating around.
 - We could to pass the ~~parent~~ real context as another argument to their `plugActionContext`, `plugComponentContext` and `plugStoreContext` functions. This _would_ require plugin authors to change code.
 - If we accept that changes may be required by plugin authors... we do already pass a reference to `this` as the second argument, plugin authors could access the resources they need from there.
 - And another option I almost forgot (mentioned in #79) is that we could require a new object be returned from these `plug*Context` functions. This approach may be the easier change to implement for plugin authors.

Your thoughts are welcome.