### PR TITLE
Provide higher order components for convenient store listening and context propagation

### DIFF
--- a/addons/BaseStore.js
+++ b/addons/BaseStore.js
@@ -1,1 +1,7 @@
+/**
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+'use strict';
+
 module.exports = require('dispatchr/addons/BaseStore');

--- a/addons/FluxibleComponent.js
+++ b/addons/FluxibleComponent.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+'use strict';
+
+var React = require('react/addons');
+var contextTypes = require('../lib/contextTypes');
+
+var FluxibleComponent = React.createClass({
+    displayName: 'FluxibleComponent',
+    propTypes: {
+        context: React.PropTypes.object.isRequired
+    },
+
+    childContextTypes: contextTypes,
+
+    /**
+     * Provides the current context as a child context
+     * @method getChildContext
+     */
+    getChildContext: function () {
+        return {
+            getStore: this.props.context.getStore,
+            executeAction: this.props.context.executeAction
+        };
+    },
+
+    render: function () {
+        return React.addons.cloneWithProps(this.props.children, this.props);
+    }
+});
+
+module.exports = FluxibleComponent;

--- a/addons/FluxibleMixin.js
+++ b/addons/FluxibleMixin.js
@@ -1,0 +1,204 @@
+/**
+ * Copyright 2014, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+'use strict';
+
+/**
+ * React mixin for staticly declaring and add/remove-ing listeners for Store events.
+ * @class FluxibleMixin
+ * @example
+ * // Register listener default handler function name
+ * var Component = React.createClass({
+ *     mixins: [FluxibleMixin],
+ *     statics: {
+ *         storeListeners: [FooStore]
+ *     },
+ *     onChange: function () {
+ *         this.setState(this.context.getStore(FooStore).getState());
+ *     },
+ *     ...
+ * });
+ * @example
+ * // Register listener with custom named handler
+ * var Component = React.createClass({
+ *     mixins: [FluxibleMixin],
+ *     statics: {
+ *         storeListeners: {
+ *             'onChange2': [FooStore]
+ *         }
+ *     },
+ *     onChange2: function () {
+ *         this.setState(this.context.getStore(FooStore).getState());
+ *     },
+ *     ...
+ * });
+ */
+var DEFAULT_CHANGE_HANDLER = 'onChange';
+var React = require('react');
+
+var FluxibleMixin = {
+
+    contextTypes: {
+        getStore: React.PropTypes.func,
+        executeAction: React.PropTypes.func
+    },
+
+    /**
+     * Registers staticly declared listeners
+     * @method componentDidMount
+     */
+    componentDidMount: function componentDidMount() {
+        this.listeners = [];
+        var self = this;
+
+        // Register static listeners
+        this.getListeners().forEach(function(listener) {
+            self._attachStoreListener(listener);
+        });
+    },
+
+    /**
+     * Calls an action
+     * @method executeAction
+     */
+    executeAction: function executeAction() {
+        var context = this.props.context || this.context;
+        if (!context || !context.executeAction) {
+            throw new Error('executeAction was called but no context was provided. Pass the fluxible' +
+            'context via a `context` prop or via React\'s context.');
+        }
+        return context.executeAction.apply(context, arguments);
+    },
+
+    /**
+     * Gets a store instance from the context
+     * @param {Function|String} store The store to get
+     * @returns {Object}
+     * @method getStore
+     */
+    getStore: function (store) {
+        var storeInstance = store;
+        if ('object' !== typeof storeInstance) {
+            var context = this.props.context || this.context;
+            if (!context) {
+                throw new Error('storeListener mixin was called but no context was provided for getting the store.' +
+                'Pass the fluxible context via a `context` prop or via React\'s context.');
+            }
+            storeInstance = context.getStore(store);
+        }
+        return storeInstance;
+    },
+
+    /**
+     * Gets from the context all store instances required by this component
+     * @returns {Object}
+     * @method getStores
+     */
+    getStores: function() {
+        var storesByName = this.getListeners().reduce(function (accum, listener) {
+            accum[listener.store.constructor.storeName] = listener.store;
+            return accum;
+        }, {});
+        return Object.keys(storesByName).map(function(storeName) {
+            return storesByName[storeName];
+        });
+    },
+
+    /**
+     * Gets a store-change handler from the component
+     * @param {Function|String} handler The handler to get
+     * @returns {Function}
+     * @method getHandler
+     */
+    getHandler: function (handler) {
+        if ('string' === typeof handler) {
+            handler = this[handler];
+        }
+
+        if (!handler) {
+            throw new Error('storeListener attempted to add undefined handler. Make sure handlers are actually exist.');
+        }
+
+        return handler;
+    },
+
+    /**
+     * Gets a listener descriptor for a store and store-change handler
+     * @param {Function|String} store Store
+     * @param {Function|String} handler The handler function or method name
+     * @returns {Object}
+     * @method getListener
+     */
+    getListener: function(store, handler) {
+        handler = this.getHandler(handler);
+        var storeInstance = this.getStore(store);
+
+        return {
+            store: storeInstance,
+            handler: handler
+        };
+    },
+
+    /**
+     * Gets all store-change listener descriptors from the component
+     * @returns {Object}
+     * @method getListeners
+     */
+    getListeners: function() {
+        var self = this;
+        var storeListeners = self.constructor.storeListeners; // Static property on component
+
+        // get static listeners
+        if (storeListeners) {
+            if (Array.isArray(storeListeners)) {
+                return storeListeners.map(function(store) {
+                    return self.getListener(store, DEFAULT_CHANGE_HANDLER);
+                });
+            } else {
+                return Object.keys(storeListeners).reduce(function (accum, handlerName) {
+                    var stores = storeListeners[handlerName];
+                    if (!Array.isArray(stores)) {
+                        stores = [stores];
+                    }
+                    return accum.concat(stores.map(function (store) {
+                        return self.getListener(store, handlerName);
+                    }));
+                }, []);
+            }
+        }
+
+        return [];
+    },
+
+    /**
+     * If provided with events, will attach listeners to events on EventEmitter objects(i.e. Stores)
+     * If the component isn't mounted, events aren't attached.
+     * @param {Object} listener
+     * @param {Object} listener.store Store instance
+     * @param {Object} listener.handler Handler function or method name
+     * @method _attachStoreListener
+     * @private
+     */
+    _attachStoreListener: function _attachStoreListener(listener) {
+        if (this.isMounted && !this.isMounted()) {
+            throw new Error('storeListener mixin called listen when component wasn\'t mounted.');
+        }
+
+        listener.store.addChangeListener(listener.handler);
+        this.listeners.push(listener);
+    },
+
+    /**
+     * Removes all listeners
+     * @method componentWillUnmount
+     */
+    componentWillUnmount: function componentWillUnmount() {
+        this.listeners.forEach(function (listener) {
+            listener.store.removeChangeListener(listener.handler);
+        });
+        this.listeners = [];
+    }
+};
+
+module.exports = FluxibleMixin;

--- a/addons/connectToStores.js
+++ b/addons/connectToStores.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+'use strict';
+
+var React = require('react');
+var objectAssign = require('object-assign');
+var contextTypes = require('../lib/contextTypes');
+
+/**
+ * Registers change listeners and retrieves state from stores using `getStateFromStores`
+ * method. Concept provided by Dan Abramov via
+ * https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750
+ * @method connectToStores
+ * @param {React.Component} Component component to pass state as props to
+ * @param {array} stores List of stores to listen for changes
+ * @param {object} storeGetters Map of storeName => stateGetterMethod used to retrieve state from the store
+ * @returns {React.Component}
+ */
+module.exports = function connectToStores(Component, stores, storeGetters) {
+    var componentName = Component.displayName || Component.name;
+    var StoreConnector = React.createClass({
+        displayName: componentName + 'StoreConnector',
+        contextTypes: {
+            getStore: contextTypes.getStore
+        },
+        getInitialState: function getInitialState() {
+            return this.getStateFromStores(this.props);
+        },
+        componentDidMount: function componentDidMount() {
+            stores.forEach(function storesEach(Store) {
+                this.context.getStore(Store).addChangeListener(this._onStoreChange);
+            }, this);
+        },
+        componentWillUnmount: function componentWillUnmount() {
+            stores.forEach(function storesEach(Store) {
+                this.context.getStore(Store).removeChangeListener(this._onStoreChange);
+            }, this);
+        },
+        getStateFromStores: function () {
+            var state = {};
+            Object.keys(storeGetters).forEach(function (storeName) {
+                var stateGetter = storeGetters[storeName];
+                var store = this.context.getStore(storeName);
+                objectAssign(state, stateGetter(store, this.props));
+            }, this);
+            return state;
+        },
+        _onStoreChange: function onStoreChange() {
+            this.setState(this.getStateFromStores());
+        },
+        render: function render() {
+            return React.createElement(Component, objectAssign({}, this.props, this.state));
+        }
+    });
+
+    return StoreConnector
+};

--- a/addons/createStore.js
+++ b/addons/createStore.js
@@ -1,1 +1,7 @@
+/**
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+'use strict';
+
 module.exports = require('dispatchr/addons/createStore');

--- a/addons/index.js
+++ b/addons/index.js
@@ -1,4 +1,14 @@
+/**
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+'use strict';
+
 module.exports = {
     BaseStore: require('./BaseStore'),
-    createStore: require('./createStore')
+    connectToStores: require('./connectToStores'),
+    createStore: require('./createStore'),
+    FluxibleComponent: require('./FluxibleComponent'),
+    FluxibleMixin: require('./FluxibleMixin'),
+    provideContext: require('./provideContext')
 };

--- a/addons/provideContext.js
+++ b/addons/provideContext.js
@@ -1,0 +1,49 @@
+var React = require('react');
+/**
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+'use strict';
+
+var objectAssign = require('object-assign');
+var contextTypes = require('../lib/contextTypes');
+
+/**
+ * Provides context prop to all children as React context
+ * @method provideContext
+ * @param {React.Component} Component component to wrap
+ * @param {object} customContextTypes Custom contextTypes to add
+ * @returns {React.Component}
+ */
+module.exports = function provideContext(Component, customContextTypes) {
+    var childContextTypes = objectAssign({}, contextTypes, customContextTypes || {});
+
+    var ContextProvider = React.createClass({
+        displayName: 'ContextProvider',
+
+        propTypes: {
+            context: React.PropTypes.object.isRequired
+        },
+
+        childContextTypes: childContextTypes,
+
+        getChildContext: function () {
+            var childContext = {
+                executeAction: this.props.context.executeAction,
+                getStore: this.props.context.getStore
+            };
+            if (customContextTypes) {
+                Object.keys(customContextTypes).forEach(function (key) {
+                    childContext[key] = this.props.context[key];
+                }, this);
+            }
+            return childContext;
+        },
+
+        render: function () {
+            return React.createElement(Component, this.props);
+        }
+    });
+
+    return ContextProvider;
+};

--- a/docs/api/Plugins.md
+++ b/docs/api/Plugins.md
@@ -52,7 +52,7 @@ let context = app.createContext({
 });
 
 context.getComponentContext().getFoo(); // returns 'bar'
-// or this.props.context.getFoo() from a React component
+// or this.context.getFoo() from a React component
 ```
 
 Example plugins:

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -3,36 +3,40 @@
 `var Fluxible = require('fluxible')` exports the following:
 
  * [`Fluxible`](Fluxible.md)
- * [`Fluxible.FluxibleComponent`](Components.md#fluxiblecomponent)
- * [`Fluxible.FluxibleMixin`](Components.md#fluxiblemixin)
 
 
 or if you're using ES6:
 
 ```js
-import {Fluxible, FluxibleComponent, FluxibleMixin} from 'fluxible';
+import Fluxible from 'fluxible';
 ```
 
 While building your application, you will need to build [stores](Stores.md), [actions](Actions.md) and connect them to your [components](Components.md).
+
+Occasionally you may find that you need to use [plugins](Plugins.md) to extend Fluxible's interfaces.
 
 ## Addons
 
 `var FluxibleAddons = require('fluxible/addons')` also provides helper utilities for creating stores:
 
- * [`FluxibleAddons.BaseStore`](Stores.md#basestore)
- * [`FluxibleAddons.createStore`](Stores.md#createstore)
+ * [`FluxibleAddons.BaseStore`](addons/BaseStore.md)
+ * [`FluxibleAddons.connectToStores`](addons/connectToStores.md)
+ * [`FluxibleAddons.createStore`](addons/CreateStore.md)
+ * [`FluxibleAddons.FluxibleComponent`](addons/FluxibleComponent.md)
+ * [`FluxibleAddons.FluxibleMixin`](addons/FluxibleMixin.md)
+ * [`FluxibleAddons.provideContext`](addons/provideContext.md)
 
 or if you're using ES6:
 
 ```js
-import {BaseStore, createStore} from 'fluxible/addons';
+import {BaseStore, connectToStores, createStore, FluxibleComponent, FluxibleMixin, provideContext} from 'fluxible/addons';
 ```
 
-These libraries are not bundled with the main Fluxible export because stores are classes that are decoupled from Fluxible entirely.
+These libraries are not bundled with the main Fluxible export because stores are decoupled from Fluxible and React integration changes as React changes.
 
 ## Utils
 
 Fluxible also provides the following utilities for testing your components:
 
-* [MockActionContext](TestUtils.md#mockactioncontext)
-* [MockComponentContext](TestUtils.md#mockcomponentcontext)
+* [createMockActionContext](Actions.md#testing)
+* [createMockComponentContext](Components.md#testing)

--- a/docs/api/Stores.md
+++ b/docs/api/Stores.md
@@ -1,6 +1,11 @@
 # API: Stores
 
-Flux stores are where you keep your application's state and handle business logic that reacts to data events. Stores in Fluxible are just classes that adhere to a simple interface. Because we want stores to be able to be completely decoupled from Fluxible, we do not provide any store implementation in our default exports, however you can use the [helper utilities](#helper-utilities) for creating your stores.
+Flux stores are where you keep your application's state and handle business 
+logic that reacts to data events. Stores in Fluxible are just classes that 
+adhere to a simple interface. Because we want stores to be able to be completely 
+decoupled from Fluxible, we do not provide any store implementation in our 
+default exports, however you can use the [helper utilities](#helper-utilities) 
+for creating your stores.
 
 ```js
 import {EventEmitter} from 'events';
@@ -40,11 +45,22 @@ ApplicationStore.handlers = {
 export default ApplicationStore;
 ```
 
+## Helper Utilities
+
+Fluxible provides a couple of helpers for building stores with some default
+behavior and convenience methods.
+
+ * [BaseStore](addons/BaseStore.md) - Store class that can be extended
+ * [createStore](addons/createStore.md) - function for creating a class that 
+extends `BaseStore`
+
 ## Interface
 
 ### Constructor
 
-The store should have a constructor function that will be used to instantiate your store using `new Store(dispatcherInterface)` where the parameters are as follows:
+The store should have a constructor function that will be used to instantiate 
+your store using `new Store(dispatcherInterface)` where the parameters are as 
+follows:
 
   * `dispatcherInterface`: An object providing access to the following methods:
     * `dispatcherInterface.getContext()`: Retrieve the [store context](#store-context)
@@ -64,7 +80,8 @@ class ExampleStore {
 }
 ```
 
-It is also recommended to extend an event emitter so that your store can emit `change` events to the components.
+It is also recommended to extend an event emitter so that your store can emit 
+`change` events to the components.
 
 ```js
 class ExampleStore extends EventEmitter {
@@ -76,7 +93,8 @@ class ExampleStore extends EventEmitter {
 
 #### storeName
 
-The store should define a static property that gives the name of the store. This is used internally and for debugging purposes.
+The store should define a static property that gives the name of the store. This 
+is used internally and for debugging purposes.
 
 ```js
 ExampleStore.storeName = 'ExampleStore';
@@ -84,7 +102,9 @@ ExampleStore.storeName = 'ExampleStore';
 
 #### handlers
 
-The store should define a static property that maps action names to handler functions or method names. These functions will be called in the event that an action has been dispatched by the Dispatchr instance.
+The store should define a static property that maps action names to handler 
+functions or method names. These functions will be called in the event that an 
+action has been dispatched by the Dispatchr instance.
 
 ```js
 ExampleStore.handlers = {
@@ -96,7 +116,8 @@ ExampleStore.handlers = {
 The handler function will be passed two parameters:
 
   * `payload`: An object containing action information.
-  * `actionName`: The name of the action. This is primarily useful when using the `default` handler
+  * `actionName`: The name of the action. This is primarily useful when using 
+the `default` handler
 
 ```js
 class ExampleStore {
@@ -107,7 +128,9 @@ class ExampleStore {
 }
 ```
 
-If you prefer to define private methods for handling actions, you can use a static function instead of a method name. This function will be bound to the store instance when it is called:
+If you prefer to define private methods for handling actions, you can use a 
+static function instead of a method name. This function will be bound to the 
+store instance when it is called:
 
 ```js
 ExampleStore.handlers = {
@@ -123,7 +146,9 @@ ExampleStore.handlers = {
 
 #### dehydrate()
 
-The store should define this function to dehydrate the store if it will be shared between server and client. It should return a serializable data object that will be passed to the client.
+The store should define this function to dehydrate the store if it will be 
+shared between server and client. It should return a serializable data object 
+that will be passed to the client.
 
 ```js
 class ExampleStore {
@@ -137,7 +162,9 @@ class ExampleStore {
 
 #### rehydrate(state)
 
-The store should define this function to rehydrate the store if it will be shared between server and client. It should restore the store to the original state using the passed `state`.
+The store should define this function to rehydrate the store if it will be 
+shared between server and client. It should restore the store to the original 
+state using the passed `state`.
 
 ```js
 class ExampleStore {
@@ -149,7 +176,10 @@ class ExampleStore {
 
 #### shouldDehydrate()
 
-The store can optionally define this function to control whether the store state should be dehydrated by the dispatcher. This method should return a boolean. If this function is undefined, the store will always be dehydrated (just as if true was returned from method).
+The store can optionally define this function to control whether the store state 
+should be dehydrated by the dispatcher. This method should return a boolean. If 
+this function is undefined, the store will always be dehydrated (just as if true 
+was returned from method).
 
 ```js
 class ExampleStore {
@@ -159,94 +189,7 @@ class ExampleStore {
 }
 ```
 
-## Helper Utilities
-
-### BaseStore
-
-A base class that you can extend to reduce boilerplate when creating stores.
-
-```js
-import {BaseStore} from 'fluxible/addons';
-```
-
-#### Built-In Methods
-
- * `emitChange()` - emits a 'change' event
- * `getContext()` - returns the [store context](FluxibleContext.md#store-context)
- * `addChangeListener(callback)` - simple method to add a change listener
- * `removeChangeListener(callback)` - removes a change listener
- * `shouldDehydrate()` - default implementation that returns true if a `change` event has been emitted
-
-```js
-import {BaseStore} from 'fluxible/addons';
-
-class ApplicationStore extends BaseStore {
-    constructor (dispatcher) {
-        super(dispatcher);
-        this.currentPageName = null;
-    }
-
-    handleReceivePage (payload) {
-        this.currentPageName = payload.pageName;
-        this.emitChange();
-    }
-
-    getCurrentPageName () {
-        return this.currentPageName;
-    }
-
-    // For sending state to the client
-    dehydrate () {
-        return {
-            currentPageName: this.currentPageName
-        };
-    }
-
-    // For rehydrating server state
-    rehydrate (state) {
-        this.currentPageName = state.currentPageName;
-    }
-}
-
-ApplicationStore.storeName = 'ApplicationStore';
-ApplicationStore.handlers = {
-    'RECEIVE_PAGE': 'handleReceivePage'
-};
-
-export default ApplicationStore;
-```
-
-### createStore
-
-A helper method similar to `React.createClass` but for creating stores that extend `BaseStore`. Also supports mixins.
-
-```js
-import {createStore} from 'fluxible/addons';
-
-export default createStore({
-    storeName: 'ApplicationStore',
-    handlers: {
-        'RECEIVE_PAGE': 'handleReceivePage'
-    },
-    handleReceivePage: function (payload) {
-        this.currentPageName = payload.pageName;
-        this.emitChange();
-    },
-    getCurrentPage: function () {
-        return this.currentPageName;
-    },
-    dehydrate: function () {
-        return {
-            currentPageName: this.currentPageName
-        };
-    },
-    rehydrate: function (state) {
-        this.currentPageName = state.currentPageName;
-    }
-});
-
-```
-
 ## Store Context
 
-The store context by default contains no methods, but can be modified by plugins.
+The store context by default contains no methods, but can be modified by 
+plugins.

--- a/docs/api/addons/BaseStore.md
+++ b/docs/api/addons/BaseStore.md
@@ -1,0 +1,56 @@
+# BaseStore
+
+```js
+import BaseStore from 'fluxible/addons/BaseStore';
+```
+
+A base class that you can extend to reduce boilerplate when creating stores.
+
+## Built-In Methods
+
+* `emitChange()` - emits a 'change' event
+* `getContext()` - returns the [store context](../FluxibleContext.md#store-context)
+* `addChangeListener(callback)` - simple method to add a change listener
+* `removeChangeListener(callback)` - removes a change listener
+* `shouldDehydrate()` - default implementation that returns true if a `change` event has been emitted
+
+## Example
+
+```js
+import {BaseStore} from 'fluxible/addons';
+
+class ApplicationStore extends BaseStore {
+    constructor (dispatcher) {
+        super(dispatcher);
+        this.currentPageName = null;
+    }
+
+    handleReceivePage (payload) {
+        this.currentPageName = payload.pageName;
+        this.emitChange();
+    }
+
+    getCurrentPageName () {
+        return this.currentPageName;
+    }
+
+    // For sending state to the client
+    dehydrate () {
+        return {
+            currentPageName: this.currentPageName
+        };
+    }
+
+    // For rehydrating server state
+    rehydrate (state) {
+        this.currentPageName = state.currentPageName;
+    }
+}
+
+ApplicationStore.storeName = 'ApplicationStore';
+ApplicationStore.handlers = {
+    'RECEIVE_PAGE': 'handleReceivePage'
+};
+
+export default ApplicationStore;
+```

--- a/docs/api/addons/FluxibleComponent.md
+++ b/docs/api/addons/FluxibleComponent.md
@@ -1,0 +1,43 @@
+# FluxibleComponent
+
+```js
+import FluxibleComponent from 'fluxible/addons/FluxibleComponent';
+```
+
+The `FluxibleComponent` is a wrapper component that will provide all of its children with access to the Fluxible component
+context via React's `childContextTypes` and `getChildContext`. This should be used to wrap your top level component. It provides access to the methods on the [component context](../Components.md#component-context).
+
+ You can get access to these methods by setting the correct `contextTypes` within your component or including the [`FluxibleMixin`](../Components.md#fluxiblemixin) which will add them for you.
+
+## Usage
+
+If you have a component that needs access to the [`ComponentContext`](../Components.md#component-context) methods:
+
+ ```js
+class Component extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = this.getStore(FooStore).getState();
+    }
+}
+Component.contextTypes = {
+    getStore: React.PropTypes.func.isRequired,
+    executeAction: React.PropTypes.func.isRequired
+};
+```
+
+you can wrap the component with `FluxibleComponent` to provide the correct context:
+
+```js
+let html = React.renderToString(
+    <FluxibleComponent context={context.getComponentContext()}>
+        <Component />
+    </FluxibleComponent>
+);
+```
+
+If you are using [`FluxibleContext.createElement()`](../FluxibleContext.md#createElementprops) this will happen for you automatically:
+
+```js
+let html = React.renderToString(context.createElement());
+```

--- a/docs/api/addons/FluxibleMixin.md
+++ b/docs/api/addons/FluxibleMixin.md
@@ -1,0 +1,53 @@
+# FluxibleMixin
+
+*** FluxibleMixin will be deprecated since React mixin support will eventually
+be removed. It is highly recommended to use [provideContext](provideContext.md)
+instead.***
+
+```js
+var FluxibleMixin = require('fluxible/addons/FluxibleMixin');
+```
+
+The mixin (accessible via `require('fluxible/addons/FluxibleMixin')`) will add the `contextTypes` `getStore` and `executeAction`
+to your component.
+
+The mixin can also be used to statically list store dependencies and listen to them automatically in `componentDidMount`. This is done by adding a static property `storeListeners` in your component.
+
+You can do this with an array, which will default all store listeners to call the `onChange` method:
+
+```js
+var FooStore = require('./stores/FooStore'); // Your store
+var Component = React.createClass({
+    mixins: [FluxibleMixin],
+    statics: {
+        storeListeners: [FooStore]
+    },
+    onChange: function () {
+        this.setState(this.getStore(FooStore).getState());
+    },
+});
+```
+
+Or you can be more explicit with which function to call for each store by using a hash:
+
+```js
+var FooStore = require('./stores/FooStore'); // Your store
+var BarStore = require('./stores/BarStore'); // Your store
+var Component = React.createClass({
+    mixins: [FluxibleMixin],
+    statics: {
+        storeListeners: {
+            onFooStoreChange: [FooStore],
+            onBarStoreChange: [BarStore]
+        }
+    },
+    onFooStoreChange: function () {
+        this.setState(this.getStore(FooStore).getState());
+    },
+    onBarStateChange: function () {
+        this.setState(this.getStore(BarStore).getState());
+    }
+});
+```
+
+This prevents boilerplate for listening to stores in `componentDidMount` and unlistening in `componentWillUnmount`.

--- a/docs/api/addons/FluxibleMixin.md
+++ b/docs/api/addons/FluxibleMixin.md
@@ -1,6 +1,6 @@
 # FluxibleMixin
 
-*** FluxibleMixin will be deprecated since React mixin support will eventually
+***FluxibleMixin will be deprecated since React mixin support will eventually
 be removed. It is highly recommended to use [provideContext](provideContext.md)
 instead.***
 

--- a/docs/api/addons/connectToStores.md
+++ b/docs/api/addons/connectToStores.md
@@ -1,0 +1,41 @@
+# `connectToStores(Component, stores, storeGetters)`
+
+```js
+import connectToStores from 'fluxible/addons/connectToStores';
+```
+
+`connectToStores` is a higher-order component that provides a convenient way to access state from the stores from within your component. It takes care of defining `getInitialState` and listening to the stores for updates. The store state will be sent to the `Component` instance as props. It is required that the React context is set and has access to `getStore`. It is recommended to use [`provideContext`](provideContext.md) around your top level component to do this for you.
+
+Takes the following parameters:
+
+ * `Component` - the component that should receive the state as props
+ * `stores` - array of store constructors to listen for changes
+ * `storeGetters` - hash of storeName -> getter function; the return values are merged as props
+
+## Example
+
+The following example will listen to changes in `FooStore` and `BarStore` and pass `foo` and `bar` as props to the `Component` when it is instantiated.
+
+```js
+class Component extends React.Component {
+    render() {
+        return (
+            <ul>
+                <li>{this.props.foo}</li>
+                <li>{this.props.bar}</li>
+            </ul>
+        );
+    }
+}
+
+Component = connectToStores(Component, [FooStore, BarStore], {
+    FooStore: (store, props) => ({
+        foo: store.getFoo()
+    }),
+    BarStore: (store, props) => ({
+        bar: store.getBar()
+    })
+});
+
+module.exports = Component;
+```

--- a/docs/api/addons/createStore.md
+++ b/docs/api/addons/createStore.md
@@ -1,0 +1,33 @@
+# createStore
+
+```js
+import createStore from 'fluxible/addons/createStore';
+```
+
+A helper method similar to `React.createClass` but for creating stores that extend [`BaseStore`](BaseStore.md). Also supports mixins.
+
+## Example
+
+```js
+export default createStore({
+    storeName: 'ApplicationStore',
+    handlers: {
+        'RECEIVE_PAGE': 'handleReceivePage'
+    },
+    handleReceivePage: function (payload) {
+        this.currentPageName = payload.pageName;
+        this.emitChange();
+    },
+    getCurrentPage: function () {
+        return this.currentPageName;
+    },
+    dehydrate: function () {
+        return {
+            currentPageName: this.currentPageName
+        };
+    },
+    rehydrate: function (state) {
+        this.currentPageName = state.currentPageName;
+    }
+});
+```

--- a/docs/api/addons/provideContext.md
+++ b/docs/api/addons/provideContext.md
@@ -1,0 +1,46 @@
+# `provideContext(Component, customContextTypes)`
+
+```js
+import provideContext from 'fluxible/addons/provideContext';
+```
+
+`providesContext` wraps the `Component` with a higher-order component that specifies the child context for you. This allows the React context to propagate to all children that specify their `contextTypes`.
+
+Receives the following parameters:
+
+ * `Component`: the component to wrap, typically your top-level application component
+ * `customContextTypes`: additional `childContextTypes` to add; useful for plugins that add to the component context
+
+By default, the `executeAction` and `getStore` methods will be added to the child context and `customContextTypes` will be merged with these defaults.
+
+## Example
+
+The most typical and basic usage of `provideContext` is to wrap your Application component to ensure that it receives the `getStore` and `executeAction` methods.
+
+```js
+class Application extends React.Component {
+    render() {
+        ...
+    }
+}
+Application = provideContext(Application);
+export default Application
+```
+
+Now when you render the Application component, you can pass in the component context via the `context` prop and be assured that all children will have access to it by specifying the respective `contextType`.
+
+```js
+React.renderToString(<WrappedComponent context={context} />);
+```
+
+If you're using the [`FluxibleContext.createElement()` method](../FluxibleContext.md#createelement-props-) and you passed a higher-order `provideContext` component to the Fluxible constructor, then the `context` prop will automatically be passed in for you.
+
+### Plugins and Custom Component Context
+
+Since plugins have the ability to add new methods or properties to the component context, you can specify custom `childContextTypes` through the second parameter.
+
+```js
+Application = provideContext(Application, {
+    foo: React.PropTypes.string
+});
+```

--- a/index.js
+++ b/index.js
@@ -2,15 +2,13 @@
  * Copyright 2014, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
-module.exports = module.exports.Fluxible = require('./lib/Fluxible');
-module.exports.FluxibleMixin = require('./lib/FluxibleMixin');
-module.exports.FluxibleComponent = require('./lib/FluxibleComponent');
+var Fluxible = require('./lib/Fluxible');
+Fluxible.Fluxible = require('./lib/Fluxible');
+Fluxible.contextTypes = require('./lib/contextTypes');
 
-// Deprecated
-var objectAssign = require('object-assign');
-module.exports.Mixin = objectAssign({}, require('./lib/FluxibleMixin'), {
-    componentWillMount: function () {
-        console.warn("require('fluxible').Mixin is deprecated. Please use " +
-        "require('fluxible').FluxibleMixin.");
-    }
-});
+// DEPRECATIONS
+// @TODO(next minor): remove all deprecations
+Fluxible.FluxibleComponent = require('./lib/FluxibleComponent');
+Fluxible.FluxibleMixin = require('./lib/FluxibleMixin');
+
+module.exports = Fluxible;

--- a/lib/Fluxible.js
+++ b/lib/Fluxible.js
@@ -36,10 +36,12 @@ function Fluxible(options) {
     this._componentActionHandler = options.componentActionHandler || this._defaultComponentActionHandler;
     this._plugins = [];
 
-    if (!this._component.hasOwnProperty('prototype')) {
-        console.warn('It is no longer necessary to wrap your component with ' +
-            '`React.createFactory` when instantiating Fluxible. Support for factories' +
-            'will be removed in the next version of Fluxible.');
+    if ('production' !== process.env.NODE_ENV) {
+        if (!this._component.hasOwnProperty('prototype')) {
+            console.warn('It is no longer necessary to wrap your component with ' +
+                '`React.createFactory` when instantiating Fluxible. Support for factories' +
+                'will be removed in the next version of Fluxible.');
+        }
     }
 
     // Initialize dependencies

--- a/lib/Fluxible.js
+++ b/lib/Fluxible.js
@@ -45,7 +45,7 @@ function Fluxible(options) {
     }
 
     // Initialize dependencies
-    this._dispatcher = dispatchr.createDispatcher();
+    this._dispatcher = dispatchr.createDispatcher(options);
 }
 
 /**

--- a/lib/FluxibleComponent.js
+++ b/lib/FluxibleComponent.js
@@ -1,30 +1,20 @@
-var React = require('react/addons');
+/**
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+'use strict';
 
-var FluxibleComponent = React.createClass({
-    displayName: 'FluxibleComponent',
-    propTypes: {
-        context: React.PropTypes.object.isRequired
-    },
+//@TODO(next minor) remove this file
+var FluxibleComponent = require('../addons/FluxibleComponent');
 
-    childContextTypes: {
-        getStore: React.PropTypes.func,
-        executeAction: React.PropTypes.func
-    },
-
-    /**
-     * Provides the current context as a child context
-     * @method getChildContext
-     */
-    getChildContext: function () {
-        return {
-            getStore: this.props.context.getStore,
-            executeAction: this.props.context.executeAction
-        };
-    },
-
-    render: function () {
-        return React.addons.cloneWithProps(this.props.children, this.props);
-    }
-});
+if ('production' !== process.env.NODE_ENV) {
+    var deprecateComponent = require('../utils/deprecateComponent');
+    FluxibleComponent = deprecateComponent(
+        FluxibleComponent,
+        "require('fluxible').FluxibleComponent has been moved out of the " +
+        "default exports for Fluxible. Please use " +
+        "require('fluxible/addons/FluxibleComponent') instead."
+    );
+}
 
 module.exports = FluxibleComponent;

--- a/lib/FluxibleContext.js
+++ b/lib/FluxibleContext.js
@@ -5,10 +5,11 @@
 'use strict';
 
 var debug = require('debug')('Fluxible:Context');
+var objectAssign = require('object-assign');
 var isPromise = require('is-promise');
 var PromiseLib = global.Promise || require('es6-promise').Promise;
 var React = require('react');
-var FluxibleComponent = React.createFactory(require('./FluxibleComponent'));
+var FluxibleComponent = require('../addons/FluxibleComponent');
 var async = require('async');
 require('setimmediate');
 
@@ -37,6 +38,9 @@ function FluxContext(options) {
     this._storeContext = null;
 }
 
+// Provied a way to override Promise only for FluxContext
+FluxContext.Promise = PromiseLib;
+
 /**
  * Creates an instance of the app level component with given props and a proper component
  * context.
@@ -48,6 +52,11 @@ FluxContext.prototype.createElement = function createElement(props) {
     if (!Component) {
         throw new Error('A component was not specified.');
     }
+    if ('ContextProvider' === Component.displayName) {
+        return React.createElement(Component, objectAssign({}, {
+            context: this.getComponentContext()
+        }, props))
+    }
     var componentInstance;
     if (!Component.hasOwnProperty('prototype')) {
         // TODO: remove factory support
@@ -55,7 +64,7 @@ FluxContext.prototype.createElement = function createElement(props) {
     } else {
         componentInstance = React.createElement(Component, props);
     }
-    return FluxibleComponent({
+    return React.createElement(FluxibleComponent, {
         context: this.getComponentContext()
     }, componentInstance);
 };
@@ -99,7 +108,8 @@ FluxContext.prototype.executeAction = function executeAction(action, payload, do
     var self = this;
     payload = (undefined !== payload) ? payload : {};
     var displayName = action.displayName || action.name;
-    var executeActionPromise = new PromiseLib(function executeActionPromise(resolve, reject) {
+    var Promise = FluxContext.Promise;
+    var executeActionPromise = new Promise(function executeActionPromise(resolve, reject) {
         debug('Executing action ' + displayName + ' with payload', payload);
         var result = action(self.getActionContext(), payload, function(err, result) {
             if (err) {

--- a/lib/FluxibleMixin.js
+++ b/lib/FluxibleMixin.js
@@ -1,204 +1,23 @@
 /**
- * Copyright 2014, Yahoo! Inc.
+ * Copyright 2015, Yahoo Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 'use strict';
 
-/**
- * React mixin for staticly declaring and add/remove-ing listeners for Store events.
- * @class FluxibleMixin
- * @example
- * // Register listener default handler function name
- * var Component = React.createClass({
- *     mixins: [FluxibleMixin],
- *     statics: {
- *         storeListeners: [FooStore]
- *     },
- *     onChange: function () {
- *         this.setState(this.context.getStore(FooStore).getState());
- *     },
- *     ...
- * });
- * @example
- * // Register listener with custom named handler
- * var Component = React.createClass({
- *     mixins: [FluxibleMixin],
- *     statics: {
- *         storeListeners: {
- *             'onChange2': [FooStore]
- *         }
- *     },
- *     onChange2: function () {
- *         this.setState(this.context.getStore(FooStore).getState());
- *     },
- *     ...
- * });
- */
-var DEFAULT_CHANGE_HANDLER = 'onChange';
-var React = require('react');
+//@TODO(next minor) remove this file
+var FluxibleMixin = require('../addons/FluxibleMixin');
 
-var FluxibleMixin = {
-
-    contextTypes: {
-        getStore: React.PropTypes.func,
-        executeAction: React.PropTypes.func
-    },
-
-    /**
-     * Registers staticly declared listeners
-     * @method componentDidMount
-     */
-    componentDidMount: function componentDidMount() {
-        this.listeners = [];
-        var self = this;
-
-        // Register static listeners
-        this.getListeners().forEach(function(listener) {
-            self._attachStoreListener(listener);
-        });
-    },
-
-    /**
-     * Calls an action
-     * @method executeAction
-     */
-    executeAction: function executeAction() {
-        var context = this.props.context || this.context;
-        if (!context || !context.executeAction) {
-            throw new Error('executeAction was called but no context was provided. Pass the fluxible' +
-            'context via a `context` prop or via React\'s context.');
+if ('production' !== process.env.NODE_ENV) {
+    var objectAssign = require('object-assign');
+    FluxibleMixin = objectAssign({}, FluxibleMixin, {
+        componentWillMount: function () {
+            console.warn(
+                "require('fluxible').FluxibleMixin has been moved out of the " +
+                "default exports for Fluxible. Please use " +
+                "require('fluxible/addons/FluxibleMixin') instead."
+            );
         }
-        return context.executeAction.apply(context, arguments);
-    },
-
-    /**
-     * Gets a store instance from the context
-     * @param {Function|String} store The store to get
-     * @returns {Object}
-     * @method getStore
-     */
-    getStore: function (store) {
-        var storeInstance = store;
-        if ('object' !== typeof storeInstance) {
-            var context = this.props.context || this.context;
-            if (!context) {
-                throw new Error('storeListener mixin was called but no context was provided for getting the store.' +
-                'Pass the fluxible context via a `context` prop or via React\'s context.');
-            }
-            storeInstance = context.getStore(store);
-        }
-        return storeInstance;
-    },
-
-    /**
-     * Gets from the context all store instances required by this component
-     * @returns {Object}
-     * @method getStores
-     */
-    getStores: function() {
-        var storesByName = this.getListeners().reduce(function (accum, listener) {
-            accum[listener.store.constructor.storeName] = listener.store;
-            return accum;
-        }, {});
-        return Object.keys(storesByName).map(function(storeName) {
-            return storesByName[storeName];
-        });
-    },
-
-    /**
-     * Gets a store-change handler from the component
-     * @param {Function|String} handler The handler to get
-     * @returns {Function}
-     * @method getHandler
-     */
-    getHandler: function (handler) {
-        if ('string' === typeof handler) {
-            handler = this[handler];
-        }
-
-        if (!handler) {
-            throw new Error('storeListener attempted to add undefined handler. Make sure handlers are actually exist.');
-        }
-
-        return handler;
-    },
-
-    /**
-     * Gets a listener descriptor for a store and store-change handler
-     * @param {Function|String} store Store
-     * @param {Function|String} handler The handler function or method name
-     * @returns {Object}
-     * @method getListener
-     */
-    getListener: function(store, handler) {
-        handler = this.getHandler(handler);
-        var storeInstance = this.getStore(store);
-
-        return {
-            store: storeInstance,
-            handler: handler
-        };
-    },
-
-    /**
-     * Gets all store-change listener descriptors from the component
-     * @returns {Object}
-     * @method getListeners
-     */
-    getListeners: function() {
-        var self = this;
-        var storeListeners = self.constructor.storeListeners; // Static property on component
-
-        // get static listeners
-        if (storeListeners) {
-            if (Array.isArray(storeListeners)) {
-                return storeListeners.map(function(store) {
-                    return self.getListener(store, DEFAULT_CHANGE_HANDLER);
-                });
-            } else {
-                return Object.keys(storeListeners).reduce(function (accum, handlerName) {
-                    var stores = storeListeners[handlerName];
-                    if (!Array.isArray(stores)) {
-                        stores = [stores];
-                    }
-                    return accum.concat(stores.map(function (store) {
-                        return self.getListener(store, handlerName);
-                    }));
-                }, []);
-            }
-        }
-
-        return [];
-    },
-
-    /**
-     * If provided with events, will attach listeners to events on EventEmitter objects(i.e. Stores)
-     * If the component isn't mounted, events aren't attached.
-     * @param {Object} listener
-     * @param {Object} listener.store Store instance
-     * @param {Object} listener.handler Handler function or method name
-     * @method _attachStoreListener
-     * @private
-     */
-    _attachStoreListener: function _attachStoreListener(listener) {
-        if (this.isMounted && !this.isMounted()) {
-            throw new Error('storeListener mixin called listen when component wasn\'t mounted.');
-        }
-
-        listener.store.addChangeListener(listener.handler);
-        this.listeners.push(listener);
-    },
-
-    /**
-     * Removes all listeners
-     * @method componentWillUnmount
-     */
-    componentWillUnmount: function componentWillUnmount() {
-        this.listeners.forEach(function (listener) {
-            listener.store.removeChangeListener(listener.handler);
-        });
-        this.listeners = [];
-    }
-};
+    });
+}
 
 module.exports = FluxibleMixin;

--- a/lib/contextTypes.js
+++ b/lib/contextTypes.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+'use strict';
+
+var React = require('react');
+
+module.exports = {
+    executeAction: React.PropTypes.func.isRequired,
+    getStore: React.PropTypes.func.isRequired
+};

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "url": "https://github.com/yahoo/fluxible"
   },
   "scripts": {
-    "test": "mocha tests/unit/ --recursive --reporter spec",
-    "cover": "istanbul cover --dir artifacts -- _mocha tests/unit/ --recursive --reporter spec",
+    "test": "mocha tests/unit/ --recursive --compilers js:babel/register --reporter spec",
+    "cover": "istanbul cover --dir artifacts -- _mocha tests/unit/ --recursive --compilers js:babel/register --reporter spec",
     "lint": "jshint"
   },
   "dependencies": {
@@ -25,6 +25,7 @@
     "react": "0.13.x"
   },
   "devDependencies": {
+    "babel": "^5.0.2",
     "chai": "^2.0.0",
     "cheerio": "^0.18.0",
     "connect-livereload": "^0.5.2",

--- a/tests/fixtures/applications/basic/components/About.jsx
+++ b/tests/fixtures/applications/basic/components/About.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 /**
  * Copyright 2014, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.

--- a/tests/fixtures/applications/basic/components/Application.jsx
+++ b/tests/fixtures/applications/basic/components/Application.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 /**
  * Copyright 2014, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.

--- a/tests/fixtures/applications/basic/components/Home.jsx
+++ b/tests/fixtures/applications/basic/components/Home.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 /**
  * Copyright 2014, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.

--- a/tests/fixtures/applications/basic/components/Nav.jsx
+++ b/tests/fixtures/applications/basic/components/Nav.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 /**
  * Copyright 2014, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.

--- a/tests/fixtures/applications/basic/components/Timestamp.jsx
+++ b/tests/fixtures/applications/basic/components/Timestamp.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 /**
  * Copyright 2014, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.

--- a/tests/fixtures/stores/BarStore.js
+++ b/tests/fixtures/stores/BarStore.js
@@ -1,0 +1,16 @@
+var createStore = require('../../../addons/createStore');
+module.exports = createStore({
+    storeName: 'BarStore',
+    handlers: {
+        'DOUBLE_UP': function () {
+            this.bar += this.bar;
+            this.emitChange();
+        }
+    },
+    initialize: function () {
+        this.bar = 'baz';
+    },
+    getBar: function () {
+        return this.bar;
+    }
+});

--- a/tests/fixtures/stores/FooStore.js
+++ b/tests/fixtures/stores/FooStore.js
@@ -1,0 +1,17 @@
+var createStore = require('../../../addons/createStore');
+
+module.exports = createStore({
+    storeName: 'FooStore',
+    handlers: {
+        'DOUBLE_UP': function () {
+            this.foo += this.foo;
+            this.emitChange();
+        }
+    },
+    initialize: function () {
+        this.foo = 'bar';
+    },
+    getFoo: function () {
+        return this.foo;
+    }
+});

--- a/tests/unit/addons/FluxibleMixin.js
+++ b/tests/unit/addons/FluxibleMixin.js
@@ -4,13 +4,13 @@
 var expect = require('chai').expect,
     React = require('react/addons'),
     ReactTestUtils = require('react/lib/ReactTestUtils'),
-    FluxibleMixin = require('../../../').FluxibleMixin,
+    FluxibleMixin = require('../../../addons').FluxibleMixin,
     createStore = require('dispatchr/addons/createStore'),
     MockStore = createStore({
-        storeName: 'MockStore'
+        storeName: 'FooStore'
     }),
     MockStore2 = createStore({
-        storeName: 'MockStore2'
+        storeName: 'BarStore'
     }),
     createMockComponentContext = require('../../../utils/createMockComponentContext'),
     jsdom = require('jsdom');
@@ -203,7 +203,7 @@ describe('StoreListenerMixin', function () {
 
         });
         it('should call context executeAction when context provided via React context', function (done) {
-            var Wrapper = React.createFactory(require('../../../index').FluxibleComponent);
+            var Wrapper = React.createFactory(require('../../../addons/FluxibleComponent'));
             var Component = React.createFactory(React.createClass({
                 displayName: 'Component',
                 contextTypes: {

--- a/tests/unit/addons/connectToStores.js
+++ b/tests/unit/addons/connectToStores.js
@@ -1,0 +1,104 @@
+/*globals describe,it,afterEach,beforeEach*/
+'use strict';
+
+var expect = require('chai').expect;
+var mockery = require('mockery');
+var React;
+var ReactTestUtils;
+var connectToStores;
+var provideContext;
+var FooStore = require('../../fixtures/stores/FooStore');
+var BarStore = require('../../fixtures/stores/BarStore');
+var createMockComponentContext = require('../../../utils/createMockComponentContext');
+var jsdom = require('jsdom');
+
+describe('connectToStores', function () {
+    var context;
+
+    beforeEach(function (done) {
+        jsdom.env('<html><body></body></html>', [], function (err, window) {
+            global.window = window;
+            global.document = window.document;
+            global.navigator = window.navigator;
+
+            context = createMockComponentContext({
+                stores: [FooStore, BarStore]
+            });
+
+            mockery.enable({
+                warnOnReplace: false,
+                warnOnUnregistered: false,
+                useCleanCache: true
+            });
+            React = require('react/addons');
+            ReactTestUtils = require('react/lib/ReactTestUtils');
+            connectToStores = require('../../../addons/connectToStores');
+            provideContext = require('../../../addons/provideContext');
+
+            done();
+        });
+    });
+
+    afterEach(function () {
+        delete global.window;
+        delete global.document;
+        delete global.navigator;
+        mockery.disable();
+    });
+
+    it('should get the state from the stores', function (done) {
+        var Component = React.createClass({
+            contextTypes: {
+                executeAction: React.PropTypes.func.isRequired
+            },
+            onClick: function () {
+                this.context.executeAction(function (actionContext) {
+                    actionContext.dispatch('DOUBLE_UP');
+                });
+            },
+            render: function () {
+                return (
+                    <div>
+                        <span id="foo">{this.props.foo}</span>
+                        <span id="bar">{this.props.bar}</span>
+                        <button id="button" onClick={this.onClick} />
+                    </div>
+                );
+            }
+        });
+        var WrappedComponent = provideContext(connectToStores(Component, [FooStore, BarStore], {
+            FooStore: function (store, props) {
+                return {
+                    foo: store.getFoo()
+                }
+            },
+            BarStore: function (store, props) {
+                return {
+                    bar: store.getBar()
+                }
+            }
+        }));
+
+        var container = document.createElement('div');
+        var component = React.render(React.createElement(WrappedComponent, {
+            context: context
+        }), container);
+        var domNode = component.getDOMNode();
+        expect(domNode.querySelector('#foo').textContent).to.equal('bar');
+        expect(domNode.querySelector('#bar').textContent).to.equal('baz');
+
+        ReactTestUtils.Simulate.click(domNode.querySelector('#button'));
+
+        expect(domNode.querySelector('#foo').textContent).to.equal('barbar');
+        expect(domNode.querySelector('#bar').textContent).to.equal('bazbaz');
+
+        expect(context.getStore(BarStore).listeners('change').length).to.equal(1);
+        expect(context.getStore(FooStore).listeners('change').length).to.equal(1);
+
+        React.unmountComponentAtNode(container);
+
+        expect(context.getStore(BarStore).listeners('change').length).to.equal(0);
+        expect(context.getStore(FooStore).listeners('change').length).to.equal(0);
+        done();
+    });
+});

--- a/tests/unit/addons/provideContext.js
+++ b/tests/unit/addons/provideContext.js
@@ -1,0 +1,34 @@
+/*globals describe,it*/
+'use strict';
+
+var expect = require('chai').expect;
+var React = require('react');
+var provideContext = require('../../../addons/provideContext');
+
+describe('provideContext', function () {
+    it('should provide the context with custom types to children', function () {
+        var context = {
+            foo: 'bar',
+            executeAction: function () {},
+            getStore: function () {}
+        };
+        var Component = React.createClass({
+            contextTypes: {
+                foo: React.PropTypes.string.isRequired,
+                executeAction: React.PropTypes.func.isRequired,
+                getStore: React.PropTypes.func.isRequired
+            },
+            render: function () {
+                expect(this.context.foo).to.equal(context.foo);
+                expect(this.context.executeAction).to.equal(context.executeAction);
+                expect(this.context.getStore).to.equal(context.getStore);
+                return null;
+            }
+        });
+        var WrappedComponent = provideContext(Component, {
+            foo: React.PropTypes.string
+        });
+
+        React.renderToString(<WrappedComponent context={context} />);
+    });
+});

--- a/tests/unit/lib/Fluxible.js
+++ b/tests/unit/lib/Fluxible.js
@@ -1,6 +1,5 @@
 /*globals describe,it,beforeEach */
 "use strict";
-require('node-jsx').install({ extension: '.jsx' });
 
 // Fix for https://github.com/joyent/node/issues/8648
 global.Promise = require('es6-promise').Promise;

--- a/utils/deprecateComponent.js
+++ b/utils/deprecateComponent.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+'use strict';
+
+var React = require('react');
+
+/**
+ * Deprecates a component by logging a warning message when used
+ * @method deprecateComponent
+ * @param {React.Component} Component component to wrap
+ * @param {string} warningMessage Custom contextTypes to add
+ * @returns {React.Component}
+ */
+module.exports = function deprecateComponent(Component, warningMessage) {
+    var DeprecationComponent = React.createClass({
+        displayName: 'DeprecationComponent',
+
+        componentWillMount: function () {
+            console.warn(warningMessage);
+        },
+
+        render: function () {
+            return React.createElement(Component, this.props);
+        }
+    });
+
+    return DeprecationComponent;
+};


### PR DESCRIPTION
Resolves:  
 * #70
 * #107

Features:

 * `connectToStores` higher order component for listening to stores and retrieving state
 * `provideContext` higher order component for setting child context on top level component

Deprecations:

With React constantly changing, I think it's best to move the React integrations outside of the default export so that adding new options for integration do not bloat core. The existing integrations will be moved to the addons folder and a warning has been introduced if used from the default export.

 * Moved `FluxibleComponent` to `addons`
 * Moved `FluxibleMixin` to `addons`

Documentation:

 * Broke out the addons into individual documents and provide summaries in parent docs with recommendations for which addon to use

Tests:

 * Switched to babel compiler for mocha tests