### PR TITLE
Should not error when no component is passed

### DIFF
--- a/lib/Fluxible.js
+++ b/lib/Fluxible.js
@@ -38,7 +38,7 @@ function Fluxible(options) {
     this._plugins = [];
 
     if ('production' !== process.env.NODE_ENV) {
-        if (!this._component.hasOwnProperty('prototype')) {
+        if (this._component && !this._component.hasOwnProperty('prototype')) {
             console.warn('It is no longer necessary to wrap your component with ' +
                 '`React.createFactory` when instantiating Fluxible. Support for factories' +
                 'will be removed in the next version of Fluxible.');


### PR DESCRIPTION
The component option in the Fluxible constructor is optional, so it shouldn't throw errors. 