### PR TITLE
Move factory warning to context.createElement

### DIFF
--- a/lib/Fluxible.js
+++ b/lib/Fluxible.js
@@ -34,14 +34,6 @@ function Fluxible(options) {
     this._componentActionHandler = options.componentActionHandler || this._defaultComponentActionHandler;
     this._plugins = [];
 
-    if ('production' !== process.env.NODE_ENV) {
-        if (this._component && !this._component.hasOwnProperty('prototype')) {
-            console.warn('It is no longer necessary to wrap your component with ' +
-                '`React.createFactory` when instantiating Fluxible. Support for factories ' +
-                'will be removed in the next version of Fluxible.');
-        }
-    }
-
     // Initialize dependencies
     this._dispatcher = dispatchr.createDispatcher(options);
 }

--- a/lib/FluxibleContext.js
+++ b/lib/FluxibleContext.js
@@ -59,6 +59,12 @@ FluxContext.prototype.createElement = function createElement(props) {
     var componentInstance;
     if (!Component.hasOwnProperty('prototype')) {
         // TODO: remove factory support
+        if ('production' !== process.env.NODE_ENV) {
+            console.warn('When using context.createFactory(), it is no longer ' +
+                'necessary to wrap your component with `React.createFactory` when ' +
+                'instantiating Fluxible. Support for factories will be removed ' +
+                'in the next version of Fluxible.');
+        }
         componentInstance = Component(props);
     } else {
         componentInstance = React.createElement(Component, props);


### PR DESCRIPTION
This warning is really only relevant when user is using `context.createElement` since they may still want a factory if they call `app.getComponent()`.

@cesarandreu @jhwang