### PR TITLE
Expose the reduce happening in connectToStores so that store state can be merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ $ npm install --save fluxible
 import Fluxible from 'fluxible';
 import React from 'react';
 import {connectToStores, createStore, provideContext} from 'fluxible/addons';
+import objectAssign from 'object-assign';
 
 // Action
 const action = (actionContext, payload) => {
@@ -75,8 +76,8 @@ class App extends React.Component {
 }
 
 App = provideContext(connectToStores(App, [FooStore], {
-    FooStore(store) {
-        return store.getState();
+    FooStore(state, store) {
+        objectAssign(state, store.getState());
     }
 }));
 

--- a/addons/connectToStores.js
+++ b/addons/connectToStores.js
@@ -15,10 +15,10 @@ var contextTypes = require('../lib/contextTypes');
  * @method connectToStores
  * @param {React.Component} Component component to pass state as props to
  * @param {array} stores List of stores to listen for changes
- * @param {object} storeGetters Map of storeName => stateGetterMethod used to retrieve state from the store
+ * @param {object} storeReducers Map of storeName -> reduce callback; should modify the first `state` argument to add state
  * @returns {React.Component}
  */
-module.exports = function connectToStores(Component, stores, storeGetters) {
+module.exports = function connectToStores(Component, stores, storeReducers) {
     var componentName = Component.displayName || Component.name;
     var StoreConnector = React.createClass({
         displayName: componentName + 'StoreConnector',
@@ -40,10 +40,13 @@ module.exports = function connectToStores(Component, stores, storeGetters) {
         },
         getStateFromStores: function () {
             var state = {};
-            Object.keys(storeGetters).forEach(function (storeName) {
-                var stateGetter = storeGetters[storeName];
-                var store = this.context.getStore(storeName);
-                objectAssign(state, stateGetter(store, this.props));
+            stores.forEach(function(store) {
+                var storeName = store.name || store.storeName || store;
+                var stateGetter = storeReducers[storeName];
+                var storeInstance = this.context.getStore(store);
+                if (stateGetter) {
+                    stateGetter(state, storeInstance, this.props)
+                }
             }, this);
             return state;
         },

--- a/docs/api/Components.md
+++ b/docs/api/Components.md
@@ -174,10 +174,8 @@ describe('TestComponent', function () {
             });
             // Wrap with context provider and store connector
             TestComponent = provideContext(connectToStores(TestComponent, [FooStore], {
-                FooStore: function (store, props) {
-                    return {
-                        foo: store.getFoo()
-                    }
+                FooStore: function (state, store, props) {
+                    state.foo = store.getFoo();
                 }
             }));
             done();

--- a/docs/api/addons/connectToStores.md
+++ b/docs/api/addons/connectToStores.md
@@ -9,8 +9,8 @@ import connectToStores from 'fluxible/addons/connectToStores';
 Takes the following parameters:
 
  * `Component` - the component that should receive the state as props
- * `stores` - array of store constructors to listen for changes
- * `storeGetters` - hash of storeName -> getter function; the return values are merged as props
+ * `stores` - array of store constructors to listen for changes; the array order defines the order the reducers are called
+ * `storeReducers` - map of storeName -> reduce callback; should modify the first `state` argument to add state
 
 ## Example
 
@@ -29,12 +29,12 @@ class Component extends React.Component {
 }
 
 Component = connectToStores(Component, [FooStore, BarStore], {
-    FooStore: (store, props) => ({
-        foo: store.getFoo()
-    }),
-    BarStore: (store, props) => ({
-        bar: store.getBar()
-    })
+    FooStore: (state, store, props) => {
+        state.foo = store.getFoo();
+    },
+    BarStore: (state, store, props) => {
+        state.bar = store.getBar()
+    }
 });
 
 module.exports = Component;

--- a/tests/unit/addons/connectToStores.js
+++ b/tests/unit/addons/connectToStores.js
@@ -67,15 +67,11 @@ describe('connectToStores', function () {
             }
         });
         var WrappedComponent = provideContext(connectToStores(Component, [FooStore, BarStore], {
-            FooStore: function (store, props) {
-                return {
-                    foo: store.getFoo()
-                }
+            FooStore: function (state, store, props) {
+                state.foo = store.getFoo();
             },
-            BarStore: function (store, props) {
-                return {
-                    bar: store.getBar()
-                }
+            BarStore: function (state, store, props) {
+                state.bar = store.getBar();
             }
         }));
 


### PR DESCRIPTION
**Breaking Change** - I don't think there is a way to make this work with the existing implementation from what I can find.

This allows the use case where state from two stores needs to be merged together, for instance `FeaturedStore` with a list of IDs and `PhotoStore` where the individual items can be retrieved:

```js
connectToStores(Component, [FeaturedStore, PhotoStore], {
    FeaturedStore: function (state, store, props) {
        state.featuredIDs = store.getFeaturedIDs();
    },
    PhotoStore: function (state, store, props) {
        state.photos = value.featuredIDs.map(function (id) {
            return store.getPhotoById(id);
        });
    }
})
```

@gpbl