### PR TITLE
Component action handler errors should be thrown

### DIFF
--- a/lib/FluxibleContext.js
+++ b/lib/FluxibleContext.js
@@ -204,9 +204,14 @@ FluxContext.prototype.getComponentContext = function getComponentContext() {
         getStore: this._dispatcher.getStore.bind(this._dispatcher),
         // Prevents components from directly handling the callback for an action
         executeAction: function componentExecuteAction(action, payload) {
-            self.executeAction(action, payload).catch(function actionHandlerWrapper(err) {
-                var noop = function () {};
-                self.executeAction(self._app._componentActionHandler, { err: err }, noop);
+            self.executeAction(action, payload)
+            .catch(function actionHandlerWrapper(err) {
+                return self.executeAction(self._app._componentActionHandler, { err: err });
+            })
+            .catch(function unhandledError(err) {
+                setImmediate(function () {
+                    throw err;
+                });
             });
         }
     };

--- a/tests/unit/lib/FluxibleContext.js
+++ b/tests/unit/lib/FluxibleContext.js
@@ -315,6 +315,29 @@ describe('FluxibleContext', function () {
 
                 componentContext2.executeAction(action, {});
             });
+            it('throws if component action handler does not handle the error', function (done) {
+                var actionError = new Error('action error');
+                var componentActionHandler = function (context, payload) {
+                    throw payload.err;
+                };
+                var action = function () {
+                    throw actionError;
+                };
+                var app2 = new Fluxible({
+                    componentActionHandler: componentActionHandler
+                });
+                var context2 = app2.createContext();
+                var componentContext2 = context2.getComponentContext();
+
+                var setImmediate = global.setImmediate;
+                global.setImmediate = function (fn) {
+                    expect(function () { fn(); }).to.throw(actionError);
+                    global.setImmediate = setImmediate;
+                    done();
+                };
+
+                componentContext2.executeAction(action, {});
+            });
         });
     });
 


### PR DESCRIPTION
In my promises PR I hadn't realized there was still the potential for swallowed errors. I stumbled upon this problem today while playing around with the new release. :(

If you execute a component action and it throws an error, it'll call component action handler. However, if component action handler throws the error again, you won't be notified.

With this update, if component action handler throws an error, it'll be thrown as expected. I think this behavior is more sensible.

Testing this is a bit hacky, but I don't know if there's a better way.