### PR TITLE
[resolves #117] Add option to pass function to connectToStores

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ const FooStore = createStore({
     handlers: {
         'FOO_ACTION': 'fooHandler'
     },
-    initialize: function () { // Set the initial state
+    initialize: () => { // Set the initial state
         this.foo = null;
     },
-    fooHandler: function (payload) {
+    fooHandler: (payload) => {
         this.foo = payload;
     },
-    getState: function () {
+    getState: () => {
         return {
             foo: this.foo
         }
@@ -74,7 +74,7 @@ class App extends React.Component {
     }
 }
 
-App = provideContext(connectToStores(App, [FooStore], function (stores) {
+App = provideContext(connectToStores(App, [FooStore], (stores, props) => {
     return stores.FooStore.getState();
 }));
 
@@ -86,7 +86,7 @@ const app = new Fluxible({
 
 // Bootstrap
 const context = app.createContext();
-context.executeAction(action, 'bar', function () {
+context.executeAction(action, 'bar', (err) => {
     console.log(React.renderToString(context.createElement()));
 });
 ```

--- a/README.md
+++ b/README.md
@@ -74,10 +74,8 @@ class App extends React.Component {
     }
 }
 
-App = provideContext(connectToStores(App, [FooStore], {
-    FooStore(store) {
-        return store.getState();
-    }
+App = provideContext(connectToStores(App, [FooStore], function (stores) {
+    return stores.FooStore.getState();
 }));
 
 // App

--- a/docs/api/Components.md
+++ b/docs/api/Components.md
@@ -173,12 +173,10 @@ describe('TestComponent', function () {
                 }
             });
             // Wrap with context provider and store connector
-            TestComponent = provideContext(connectToStores(TestComponent, [FooStore], {
-                FooStore: function (store, props) {
-                    return {
-                        foo: store.getFoo()
-                    }
-                }
+            TestComponent = provideContext(connectToStores(TestComponent, [FooStore], function (stores) {
+                return {
+                    foo: stores.FooStore.getFoo()
+                };
             }));
             done();
         });

--- a/docs/api/addons/connectToStores.md
+++ b/docs/api/addons/connectToStores.md
@@ -28,13 +28,11 @@ class Component extends React.Component {
     }
 }
 
-Component = connectToStores(Component, [FooStore, BarStore], {
-    FooStore: (store, props) => ({
-        foo: store.getFoo()
-    }),
-    BarStore: (store, props) => ({
-        bar: store.getBar()
-    })
+Component = connectToStores(Component, [FooStore, BarStore], function (stores, props) {
+    return {
+        foo: stores.FooStore.getFoo(),
+        bar: stores.BarStore.getBar()
+    };
 });
 
 module.exports = Component;


### PR DESCRIPTION
Instead of the storeGetters map 
Switched docs to use this method rather than old. The old way may be a candidate for deprecation in the next version since this way seems easier in almost all cases.