### PR TITLE
connectToStores: componentWillReceiveProps support and context access for change handlers

### DIFF
--- a/addons/connectToStores.js
+++ b/addons/connectToStores.js
@@ -19,13 +19,14 @@ var contextTypes = require('../lib/contextTypes');
  *      the full state object. Receives `stores` hash and component `props` as arguments
  * @returns {React.Component}
  */
-module.exports = function connectToStores(Component, stores, getStateFromStores) {
+module.exports = function connectToStores(Component, stores, getStateFromStores, extraContextTypes) {
     var componentName = Component.displayName || Component.name;
+    var componentContextTypes = objectAssign({
+        getStore: contextTypes.getStore
+    }, extraContextTypes);
     var StoreConnector = React.createClass({
         displayName: componentName + 'StoreConnector',
-        contextTypes: {
-            getStore: contextTypes.getStore
-        },
+        contextTypes: componentContextTypes,
         getInitialState: function getInitialState() {
             return this.getStateFromStores();
         },
@@ -49,7 +50,7 @@ module.exports = function connectToStores(Component, stores, getStateFromStores)
                     var storeName = store.name || store.storeName || store;
                     storeInstances[storeName] = this.context.getStore(store);
                 }, this);
-                return getStateFromStores(storeInstances, overrideProps || this.props);
+                return getStateFromStores(storeInstances, overrideProps || this.props, this.context);
             }
             var state = {};
             //@TODO deprecate?

--- a/addons/connectToStores.js
+++ b/addons/connectToStores.js
@@ -27,33 +27,36 @@ module.exports = function connectToStores(Component, stores, getStateFromStores)
             getStore: contextTypes.getStore
         },
         getInitialState: function getInitialState() {
-            return this.getStateFromStores(this.props);
+            return this.getStateFromStores();
         },
         componentDidMount: function componentDidMount() {
             stores.forEach(function storesEach(Store) {
                 this.context.getStore(Store).addChangeListener(this._onStoreChange);
             }, this);
         },
+        componentWillReceiveProps: function(nextProps) {
+            this.setState(this.getStateFromStores(nextProps));
+        },
         componentWillUnmount: function componentWillUnmount() {
             stores.forEach(function storesEach(Store) {
                 this.context.getStore(Store).removeChangeListener(this._onStoreChange);
             }, this);
         },
-        getStateFromStores: function () {
+        getStateFromStores: function (overrideProps) {
             if ('function' === typeof getStateFromStores) {
                 var storeInstances = {};
                 stores.forEach(function (store) {
                     var storeName = store.name || store.storeName || store;
                     storeInstances[storeName] = this.context.getStore(store);
                 }, this);
-                return getStateFromStores(storeInstances, this.props);
+                return getStateFromStores(storeInstances, overrideProps || this.props);
             }
             var state = {};
             //@TODO deprecate?
             Object.keys(getStateFromStores).forEach(function (storeName) {
                 var stateGetter = getStateFromStores[storeName];
                 var store = this.context.getStore(storeName);
-                objectAssign(state, stateGetter(store, this.props));
+                objectAssign(state, stateGetter(store, overrideProps || this.props));
             }, this);
             return state;
         },
@@ -65,5 +68,5 @@ module.exports = function connectToStores(Component, stores, getStateFromStores)
         }
     });
 
-    return StoreConnector
+    return StoreConnector;
 };


### PR DESCRIPTION
React-Router triggers a componentWillReceiveProps when you stay within the same route but the params or queries change (for example, navigating from one todo directly to another). Without componentWillReceiveProps in the route handlers (the wrapped components in this case) you can't get new data from the store when this happens.

The second change in the second commit isn't necessary but felt like the logical next step. It allows you to pass in contextTypes to access from the stateGetter(s). React-Router v0.13 uses context as well, and the only way to access route params/queries is through the component context. Without access to context you either have to always just get the whole store state and do the 'selecting' in your component, but that doesn't feel like the right place to do those things in this architecture.

What do you think?

Example of context usage:
```javascript
Component = connectToStores(Component, [TodoStore], (stores, props, context) => {
    let params = context.router.getCurrentParams();
    return {
        todo: stores.ToDoStore.get(params.id)
    };
}, {
    router: React.PropTypes.func.isRequired
});
```

(Also corrected two small things in the process, props were passed through to `getStateFromStores` in `getInitialState` but there was no parameter for it, and `return StoreConnector;` didn't have a semicolon.)