### PR TITLE
Update outdated connectToStores docs

### DIFF
--- a/docs/api/addons/connectToStores.md
+++ b/docs/api/addons/connectToStores.md
@@ -10,7 +10,7 @@ Takes the following parameters:
 
  * `Component` - the component that should receive the state as props
  * `stores` - array of store constructors to listen for changes
- * `storeGetters` - hash of storeName -> getter function; the return values are merged as props
+ * `getStateFromStores` - function that receives all stores and should return the full state object. Receives `stores` hash and component `props` as arguments
 
 ## Example
 


### PR DESCRIPTION
Not sure if should just update docs with getStateFromStores function and skip mentioning storeGetters, or if storeGetters should be mentioned (since it's not (deprecated yet)[https://github.com/yahoo/fluxible/blob/master/addons/connectToStores.js#L52]).

But it's weird that the example below this is using the getStateFromStores function instead of storeGetters.