### PR TITLE
Make context.executeAction return executeActionPromise

### DIFF
--- a/lib/FluxibleContext.js
+++ b/lib/FluxibleContext.js
@@ -203,8 +203,8 @@ FluxContext.prototype.getComponentContext = function getComponentContext() {
     var componentContext = {
         getStore: this._dispatcher.getStore.bind(this._dispatcher),
         // Prevents components from directly handling the callback for an action
-        executeAction: function componentExecuteAction(action, payload) {
-            self.executeAction(action, payload)
+        executeAction: function componentExecuteAction(action, payload, done) {
+            return self.executeAction(action, payload, done)
             .catch(function actionHandlerWrapper(err) {
                 return self.executeAction(self._app._componentActionHandler, { err: err });
             })


### PR DESCRIPTION
According to [document](http://fluxible.io/api/fluxible-context.html#executeaction-action-payload-done-), `executeAction` method has optional callback and returns `executeActionPromise`.

But `this.context.executeAction` seems to return `undefined` and `done` callback is ignored, I fix it.

```jsx
const Component = React.createClass({
  contextTypes: {
    getStore: React.PropTypes.func.isRequired,
    executeAction: React.PropTypes.func.isRequired
  },
  componentDidMount() {
    this.context.executeAction(SomeAction, {}, done); // returns undefined, done won't called.
  },
  render() {
    return <div />;
  }
});

module.exports = provideContext(connectToStores(Component, [SomeStore], (stores) => {
  return stores.SomeStore.getState();
}));
```