### PR TITLE
[Resolves #133] Warn when a callback is passed into executeAction from component

### DIFF
--- a/docs/api/Components.md
+++ b/docs/api/Components.md
@@ -9,7 +9,7 @@ The component context receives limited access to the [FluxibleContext](FluxibleC
  * `executeAction(action, payload)`
  * `getStore(storeConstructor)`
 
-It's important to note that `executeAction` does not allow passing a callback from the component. This enforces that the actions are fire-and-forget and that state changes should only be handled through the Flux flow. You may however provide an app level `componentActionHandler` function when instantiating Fluxible. This allows you to handle errors (at a high level) spawning from components firing actions.
+It's important to note that ***`executeAction` does not allow passing a callback from the component***. This enforces that the actions are fire-and-forget and that state changes should only be handled through the Flux flow. You may however provide an app level `componentActionHandler` function when instantiating Fluxible. This allows you to handle errors (at a high level) spawning from components firing actions.
 
 ## Accessing the Context
 

--- a/lib/FluxibleContext.js
+++ b/lib/FluxibleContext.js
@@ -203,7 +203,12 @@ FluxContext.prototype.getComponentContext = function getComponentContext() {
     var componentContext = {
         getStore: this._dispatcher.getStore.bind(this._dispatcher),
         // Prevents components from directly handling the callback for an action
-        executeAction: function componentExecuteAction(action, payload) {
+        executeAction: function componentExecuteAction(action, payload, done) {
+            if (done) {
+                console.warn('When calling executeAction from a component,' +
+                             'a callback isn\'t allowed. See our docs for more info:' +
+                             'http://fluxible.io/api/components.html#component-context');
+            }
             self.executeAction(action, payload)
             .catch(function actionHandlerWrapper(err) {
                 return self.executeAction(self._app._componentActionHandler, { err: err });


### PR DESCRIPTION
I actually wouldn't even be opposed to throwing an error.

@mridgway @redonkulus 