### PR TITLE
Reinstate setimmediate

### DIFF
--- a/lib/FluxibleContext.js
+++ b/lib/FluxibleContext.js
@@ -114,6 +114,18 @@ FluxContext.prototype.executeAction = function executeAction(action, payload, do
     payload = (undefined !== payload) ? payload : {};
     var displayName = action.displayName || action.name;
     var Promise = FluxContext.Promise;
+    if (process.env.NODE_ENV !== 'production') {
+        if (this._dispatcher.currentAction) {
+            var currentActionDisplayName = this._dispatcher.currentAction.displayName ||
+                this._dispatcher.currentAction.name;
+
+            console.warn('Warning: executeAction for `' + displayName + '` was called, but `' +
+                currentActionDisplayName + '` is currently being dispatched. This could mean ' +
+                'there are cascading updates, which should be avoided. `' + displayName +
+                '` will only start after `' + currentActionDisplayName + '` is complete.');
+        }
+    }
+
     var executeActionPromise = new Promise(function executeActionPromise(resolve, reject) {
         debug('Executing action ' + displayName + ' with payload', payload);
         setImmediate(function () {

--- a/lib/FluxibleContext.js
+++ b/lib/FluxibleContext.js
@@ -116,18 +116,13 @@ FluxContext.prototype.executeAction = function executeAction(action, payload, do
     var Promise = FluxContext.Promise;
     var executeActionPromise = new Promise(function executeActionPromise(resolve, reject) {
         debug('Executing action ' + displayName + ' with payload', payload);
-        var result = action(self.getActionContext(), payload, function(err, result) {
-            if (err) {
+        setImmediate(function () {
+            try {
+                executeActionInternal(self, action, payload, resolve, reject);
+            } catch (err) {
                 reject(err);
-            } else {
-                resolve(result);
             }
         });
-        if (isPromise(result)) {
-            result.then(resolve, reject);
-        } else if (action.length < 3) {
-            resolve(result);
-        }
     });
 
     if (done) {
@@ -143,6 +138,33 @@ FluxContext.prototype.executeAction = function executeAction(action, payload, do
 
     return executeActionPromise;
 };
+
+/**
+ * Executes an action, and calls either resolve or reject based on the callback result
+ * This is extracted from FluxContext.prototype.executeAction to prevent this method de-optimising
+ * due to the try/catch
+ * @param {Object} context FluxContext object
+ * @param {Function} action Action to call
+ * @param {Object} payload Payload for the action
+ * @param {Function} resolve function to call on success
+ * @param {Function} reject function to call on failure
+ * @private
+ */
+function executeActionInternal(context, action, payload, resolve, reject) {
+    var result = action(context.getActionContext(), payload, function (err, result) {
+        if (err) {
+            reject(err);
+        } else {
+            resolve(result);
+        }
+    });
+    if (isPromise(result)) {
+        result.then(resolve, reject);
+    } else if (action.length < 3) {
+        resolve(result);
+    }
+}
+
 
 /**
  * Sets up the dispatcher with access to the store context

--- a/tests/unit/lib/FluxibleContext.js
+++ b/tests/unit/lib/FluxibleContext.js
@@ -251,12 +251,59 @@ describe('FluxibleContext', function () {
                 var payload = {};
                 actionContext.executeAction(action, payload)
                 .catch(function (actionError) {
-                    expect(actionError).to.equal(err);
-                    expect(actionCalls.length).to.equal(1);
-                    expect(actionCalls[0].context).to.equal(actionContext);
-                    expect(actionCalls[0].payload).to.equal(payload);
-                    done();
+                        try {
+                            expect(actionError).to.equal(err);
+                            expect(actionCalls.length).to.equal(1);
+                            expect(actionCalls[0].context).to.equal(actionContext);
+                            expect(actionCalls[0].payload).to.equal(payload);
+                            done();
+                        } catch (e) {
+                            done(e);
+                        }
                 });
+            });
+
+            it('should execute the action asynchronously when using a callback', function (done) {
+                var log = [];
+                var action = function (context, payload, callback) {
+                    log.push('action');
+                    callback();
+                };
+                var payload = {};
+                var callback = function () {
+                    try {
+                        expect(log).to.deep.equal(['start', 'after executeAction', 'action']);
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
+                };
+                log.push('start');
+                actionContext.executeAction(action, payload, callback);
+                log.push('after executeAction')
+            });
+
+            it('should execute the action asynchronously when using a promise', function (done) {
+                var log = [];
+                var action = function (context, payload) {
+                    return new Promise(function (resolve) {
+                        log.push('action');
+                        resolve();
+                    });
+                };
+                var payload = {};
+
+                log.push('start');
+                actionContext.executeAction(action, payload)
+                    .then(function () {
+                        try {
+                            expect(log).to.deep.equal(['start', 'after executeAction', 'action']);
+                            done();
+                        } catch (e) {
+                            done(e);
+                        }
+                    });
+                log.push('after executeAction')
             });
 
             it('should not coerce non-objects', function (done) {

--- a/tests/unit/lib/FluxibleContext.js
+++ b/tests/unit/lib/FluxibleContext.js
@@ -8,6 +8,7 @@ var Fluxible = require('../../../');
 var FluxibleContext = require('../../../lib/FluxibleContext');
 var isPromise = require('is-promise');
 var React = require('react');
+var createStore = require('dispatchr/addons/createStore');
 var domain = require('domain');
 
 // Fix for https://github.com/joyent/node/issues/8648
@@ -320,6 +321,81 @@ describe('FluxibleContext', function () {
                 actionContext.executeAction(action, payload, function () {
                     expect(actionCalls[0].payload).to.equal(false);
                     done();
+                });
+            });
+
+            describe('simultaneous actions', function () {
+                var originalWarn;
+                var warningCalls;
+
+                var store;
+
+                beforeEach(function () {
+
+                    originalWarn = console.warn;
+                    warningCalls = [];
+                    console.warn = function () {
+                        warningCalls.push(Array.prototype.slice.call(arguments));
+                    };
+
+                    store = createStore({
+
+                        storeName: 'TestStore',
+
+                        handlers: {
+                            'TEST': function () {
+                                console.log('Emitting change');
+                                this.emitChange();
+                            }
+                        }
+                    });
+
+                    app.registerStore(store);
+                });
+
+                afterEach(function () {
+                    console.warn = originalWarn;
+                });
+
+                it('should output a warning when an action is currently being dispatched', function (done) {
+
+                    var action1ExecuteCount = 0;
+                    var action2ExecuteCount = 0;
+                    var payload = {};
+
+                    var action1 = function action1(context, payload, callback) {
+                        context.dispatch('TEST', payload);
+                        action1ExecuteCount++;
+
+                        callback();
+                    };
+
+                    var action2 = function action2(context, payload, callback) {
+                        action2ExecuteCount++;
+                        callback()
+                    };
+
+                    var storeInstance = actionContext.getStore(store);
+                    storeInstance.addChangeListener(function () {
+                        console.log('Got change from store, executing action');
+                        actionContext.executeAction(action2, payload, function () {
+                            try {
+                                expect(warningCalls.length).to.equal(1);
+                                expect(warningCalls[0][0]).to.equal('Warning: executeAction for `action2` was ' +
+                                'called, but `TEST` is currently being dispatched. This could mean there are ' +
+                                'cascading updates, which should be avoided. `action2` will only start after ' +
+                                '`TEST` is complete.');
+                                expect(action1ExecuteCount).to.equal(1);
+                                expect(action2ExecuteCount).to.equal(1);
+                                done();
+                            } catch (e) {
+                                done(e);
+                            }
+                        });
+                    });
+
+                    actionContext.executeAction(action1)
+
                 });
             });
         });


### PR DESCRIPTION
setImmediate used again for executeAction, inside the promise.

A warning is given on the console in development mode when an action is currently dispatching when executeAction is called (as a hint for cascading updates).

Errors thrown from the action are caught, and the promise is rejected, or the callback is called with the error.

Resolves #139 