### PR TITLE
Stopped FluxibleComponent from double rendering

### DIFF
--- a/addons/FluxibleComponent.js
+++ b/addons/FluxibleComponent.js
@@ -27,7 +27,7 @@ var FluxibleComponent = React.createClass({
     },
 
     render: function () {
-        return React.addons.cloneWithProps(this.props.children, this.props);
+        return React.addons.cloneWithProps(this.props.children);
     }
 });
 

--- a/tests/unit/addons/FluxibleComponent.js
+++ b/tests/unit/addons/FluxibleComponent.js
@@ -1,0 +1,68 @@
+/*globals describe,it,afterEach,beforeEach*/
+'use strict';
+
+var expect = require('chai').expect;
+var mockery = require('mockery');
+var React;
+var ReactTestUtils;
+var connectToStores;
+var provideContext;
+var FluxibleComponent;
+var FooStore = require('../../fixtures/stores/FooStore');
+var BarStore = require('../../fixtures/stores/BarStore');
+var createMockComponentContext = require('../../../utils/createMockComponentContext');
+var jsdom = require('jsdom');
+
+describe('fluxibleComponent', function () {
+    var context;
+
+    beforeEach(function (done) {
+        jsdom.env('<html><body></body></html>', [], function (err, window) {
+            global.window = window;
+            global.document = window.document;
+            global.navigator = window.navigator;
+
+            context = createMockComponentContext({
+                stores: [FooStore, BarStore]
+            });
+
+            mockery.enable({
+                warnOnReplace: false,
+                warnOnUnregistered: false,
+                useCleanCache: true
+            });
+            React = require('react/addons');
+            ReactTestUtils = require('react/lib/ReactTestUtils');
+            connectToStores = require('../../../addons/connectToStores');
+            provideContext = require('../../../addons/provideContext');
+            FluxibleComponent = require('../../../addons/FluxibleComponent');
+
+            done();
+        });
+    });
+
+    afterEach(function () {
+        delete global.window;
+        delete global.document;
+        delete global.navigator;
+        mockery.disable();
+    });
+
+    it('will not double render', function () {
+        const Component = React.createClass({
+            render: function() {
+                return (
+                    <div className="Component">{this.props.children}</div>
+                );
+            }
+        });
+        const element = ReactTestUtils.renderIntoDocument(
+            <FluxibleComponent context={context}>
+                <Component>Some child</Component>
+            </FluxibleComponent>
+        );
+        expect(React.findDOMNode(element).outerHTML).to.equal(
+            '<div class="Component" data-reactid=".0">Some child</div>'
+        );
+    });
+});


### PR DESCRIPTION
Fixed case where wrapping component with fluxible would cause component to double render its childen prop.

The test would initially render
```html
<div class="Component" data-reactid=".0"><div class="Component" data-reactid=".0.0">Some child</div></div>
```

This is however at the cost of not passing the props from FluxibleComponent to the component. Perhaps omitting `this.props.children` is a better solution.