### PR TITLE
Update routing.md

### DIFF
--- a/docs/tutorials/routing.md
+++ b/docs/tutorials/routing.md
@@ -14,7 +14,7 @@ example](https://github.com/yahoo/flux-examples/tree/master/fluxible-router).
 
 Let's start by creating a very basic React component.
 
-File: `/components/Application.jsx`
+File: `/components/Application.js`
 
 ```js
 var React = require('react');


### PR DESCRIPTION
A Slack transcript:

> chriscorwin [1:48 PM] 
> Hello all. :simple_smile:
> 
> I’m poking at Fluxible — going through the router tutorial at:
> 
> http://fluxible.io/tutorials/routing.html#routing
> 
> …which mentions that the latest code is available on GitHub.
> 
> The first bit of code says the file is `/components/Application.jsx` … but the GitHub repo contains `/components/Application.js`.
> 
> https://github.com/yahoo/flux-examples/blob/master/fluxible-router/components/Application.js
> 
> Now: I understand that there’s some… sorta… weirdness with .js vs .jsx but should I just ignore these discrepancies while I’m learning and dive on?
> 
> Or is there some big disconnect that I’m missing that may lead me astray?
> 
> GitHub
> yahoo/flux-examples
> flux-examples - Isomorphic Flux examples with Fluxible
> 
> mridgway [2:05 PM] 
> @chriscorwin: Ah, yeah we renamed that file to .js when we switched to using babel. The doc should be updated to reflect that.
> 
> chriscorwin [2:07 PM] 
> Cool, so: “don’t really worry about it, plow ahead”  ?
> 
> :smile:
> NEW MESSAGES
> 
> mridgway [2:09 PM] 
> ha, exactly

https://reactiflux.slack.com/archives/fluxible/p1430417103000265