### PR TITLE
Making promise example less verbose and reducing duplication

### DIFF
--- a/docs/api/Actions.md
+++ b/docs/api/Actions.md
@@ -21,12 +21,9 @@ If the action returns a promise, executeAction will wait for it to be resolved o
 
 ```js
 export default function myPromiseAction(actionContext, payload) {
-    return new Promise(function (resolve, reject) {
-        getServerData(payload)
-            .then(function (data) {
-                actionContext.dispatch('RECEIVED_SERVER_DATA', data);
-            })
-            .then(resolve, reject);
+    return getServerData(payload).then(function (data) {
+            actionContext.dispatch('RECEIVED_SERVER_DATA', data);
+        });
     });
 };
 ```


### PR DESCRIPTION
Maybe I'm too used to promises but if you can chain a .then to a method it seems obvious to me it's already returning a promise.