### PR TITLE
Avoid calling setState when component is being unmounted

### DIFF
--- a/addons/connectToStores.js
+++ b/addons/connectToStores.js
@@ -58,7 +58,9 @@ module.exports = function connectToStores(Component, stores, getStateFromStores)
             return state;
         },
         _onStoreChange: function onStoreChange() {
-            this.setState(this.getStateFromStores());
+            if (this.isMounted()) {
+                this.setState(this.getStateFromStores());
+            }
         },
         render: function render() {
             return React.createElement(Component, objectAssign({}, this.props, this.state));

--- a/tests/unit/lib/FluxibleContext.js
+++ b/tests/unit/lib/FluxibleContext.js
@@ -344,7 +344,6 @@ describe('FluxibleContext', function () {
 
                         handlers: {
                             'TEST': function () {
-                                console.log('Emitting change');
                                 this.emitChange();
                             }
                         }
@@ -377,7 +376,6 @@ describe('FluxibleContext', function () {
 
                     var storeInstance = actionContext.getStore(store);
                     storeInstance.addChangeListener(function () {
-                        console.log('Got change from store, executing action');
                         actionContext.executeAction(action2, payload, function () {
                             try {
                                 expect(warningCalls.length).to.equal(1);


### PR DESCRIPTION
This avoids an issue where you have a parent and a child both listening to the same store, where parent could re-render in the middle of handling the change event causing the child to be unmounted. When this happens, the child's call to `setState` will cause a warning.

It's important to note here that the `isMounted()` may be removed in the future: https://facebook.github.io/react/docs/component-api.html#ismounted. If this happens we will either need to implement our own flag (using `componentWillUnmount`) or hope that an alternative is found. See https://github.com/facebook/react/issues/2787 for discussion on this warning and whether it's needed or not. 

Also fixes https://github.com/yahoo/fluxible-router/issues/18