### PR TITLE
Fixed race condition

### DIFF
--- a/addons/connectToStores.js
+++ b/addons/connectToStores.js
@@ -58,7 +58,9 @@ module.exports = function connectToStores(Component, stores, getStateFromStores)
             return state;
         },
         _onStoreChange: function onStoreChange() {
-            this.setState(this.getStateFromStores());
+            if (this.isMounted()) {
+                this.setState(this.getStateFromStores());
+            }
         },
         render: function render() {
             return React.createElement(Component, objectAssign({}, this.props, this.state));


### PR DESCRIPTION
I'm not sure about this one but when a component is owned by another one and both listen to the same store changes; if the child component in unmounted, `_onStoreChange` is called right after `componentWillUnmount` and so a `setState` call is initiated on it, and it shouldn't.

I just added a test to make sure the component if mounted before trying to call `setState`.

That fixes my use-case but maybe that worth looking more into it.