### PR TITLE
Support for IE8 added when using promise.catch(func).

### DIFF
--- a/lib/FluxibleContext.js
+++ b/lib/FluxibleContext.js
@@ -239,10 +239,10 @@ FluxContext.prototype.getComponentContext = function getComponentContext() {
         // Prevents components from directly handling the callback for an action
         executeAction: function componentExecuteAction(action, payload) {
             self.executeAction(action, payload)
-            .catch(function actionHandlerWrapper(err) {
+            .then(undefined, function actionHandlerWrapper(err) {
                 return self.executeAction(self._app._componentActionHandler, { err: err });
             })
-            .catch(function unhandledError(err) {
+            .then(undefined, function unhandledError(err) {
                 setImmediate(function () {
                     throw err;
                 });

--- a/lib/FluxibleContext.js
+++ b/lib/FluxibleContext.js
@@ -239,10 +239,10 @@ FluxContext.prototype.getComponentContext = function getComponentContext() {
         // Prevents components from directly handling the callback for an action
         executeAction: function componentExecuteAction(action, payload) {
             self.executeAction(action, payload)
-            .then(undefined, function actionHandlerWrapper(err) {
+            ['catch'](function actionHandlerWrapper(err) {
                 return self.executeAction(self._app._componentActionHandler, { err: err });
             })
-            .then(undefined, function unhandledError(err) {
+            ['catch'](function unhandledError(err) {
                 setImmediate(function () {
                     throw err;
                 });


### PR DESCRIPTION
## Usage in IE<9

`catch` is a reserved word in IE<9, meaning `promise.catch(func)` throws a syntax error. There are some workarounds specifically for IE8.

However, please remember that such techniques are already provided by most common minifiers, making the resulting code safe for old browsers and production, but when using `browserify` as bundler and `uglify` as minifer, the issues on IE8 are still present.

So I've replaced `.catch` with `.then`

```js
promise.then(undefined, function(err) {
  // ...
});
```