### PR TITLE
[resolves #143] Fix precedence for store name

### DIFF
--- a/addons/connectToStores.js
+++ b/addons/connectToStores.js
@@ -43,7 +43,7 @@ module.exports = function connectToStores(Component, stores, getStateFromStores)
             if ('function' === typeof getStateFromStores) {
                 var storeInstances = {};
                 stores.forEach(function (store) {
-                    var storeName = store.name || store.storeName || store;
+                    var storeName = store.storeName || store.name || store;
                     storeInstances[storeName] = this.context.getStore(store);
                 }, this);
                 return getStateFromStores(storeInstances, this.props);


### PR DESCRIPTION
This will fix the `connectToStores` functionality in minified environments as long as users specify a `storeName` static property.

A separate PR should be done in dispatchr to warn users if they rely on the `store.name` property only.