### PR TITLE
Export mock context class as well as create context functions

### DIFF
--- a/utils/MockActionContext.js
+++ b/utils/MockActionContext.js
@@ -4,6 +4,30 @@
  */
 'use strict';
 
-throw new Error("`require('fluxible/utils/MockActionContext')` has been removed in " +
-    "favor of `require('fluxible/utils').createMockActionContext; See " +
-    "https://github.com/yahoo/fluxible/pull/99 for details.`");
+function MockActionContext (dispatcherContext) {
+    this.dispatcherContext = dispatcherContext;
+    this.executeActionCalls = [];
+    this.dispatchCalls = [];
+}
+
+MockActionContext.prototype.getStore = function (name) {
+    return this.dispatcherContext.getStore(name);
+};
+
+MockActionContext.prototype.dispatch = function (name, payload) {
+    this.dispatchCalls.push({
+        name: name,
+        payload: payload
+    });
+    this.dispatcherContext.dispatch(name, payload);
+};
+
+MockActionContext.prototype.executeAction = function (action, payload, callback) {
+    this.executeActionCalls.push({
+        action: action,
+        payload: payload
+    });
+    action(this, payload, callback);
+};
+
+module.exports = MockActionContext;

--- a/utils/MockComponentContext.js
+++ b/utils/MockComponentContext.js
@@ -4,6 +4,28 @@
  */
 'use strict';
 
-throw new Error("`require('fluxible/utils/MockComponentContext')` has been removed in " +
-    "favor of `require('fluxible/utils').createMockComponentContext; See " +
-    "https://github.com/yahoo/fluxible/pull/99 for details.`");
+var createMockActionContext = require('./createMockActionContext');
+function noop () {}
+
+function MockComponentContext (dispatcherContext) {
+    this.dispatcherContext = dispatcherContext;
+    this.executeActionCalls = [];
+    this.getStore = this.getStore.bind(this);
+    this.executeAction = this.executeAction.bind(this);
+}
+
+MockComponentContext.prototype.getStore = function (name) {
+    return this.dispatcherContext.getStore(name);
+};
+
+MockComponentContext.prototype.executeAction = function (action, payload) {
+    this.executeActionCalls.push({
+        action: action,
+        payload: payload
+    });
+    action(createMockActionContext({
+        dispatcherContext: this.dispatcherContext
+    }), payload, noop);
+};
+
+module.exports = MockComponentContext;

--- a/utils/createMockActionContext.js
+++ b/utils/createMockActionContext.js
@@ -5,40 +5,16 @@
 'use strict';
 
 var dispatchr = require('dispatchr');
-
-function MockActionContext (dispatcherContext) {
-    this.dispatcherContext = dispatcherContext;
-    this.executeActionCalls = [];
-    this.dispatchCalls = [];
-}
-
-MockActionContext.prototype.getStore = function (name) {
-    return this.dispatcherContext.getStore(name);
-};
-
-MockActionContext.prototype.dispatch = function (name, payload) {
-    this.dispatchCalls.push({
-        name: name,
-        payload: payload
-    });
-    this.dispatcherContext.dispatch(name, payload);
-};
-
-MockActionContext.prototype.executeAction = function (action, payload, callback) {
-    this.executeActionCalls.push({
-        action: action,
-        payload: payload
-    });
-    action(this, payload, callback);
-};
+var MockActionContextClass = require('./MockActionContext');
 
 module.exports = function createMockActionContext(options) {
     options = options || {};
+    options.mockActionContextClass = options.mockActionContextClass || MockActionContextClass;
     options.stores = options.stores || [];
     options.dispatcher = options.dispatcher || dispatchr.createDispatcher({
         stores: options.stores
     });
     options.dispatcherContext = options.dispatcherContext || options.dispatcher.createContext();
 
-    return new MockActionContext(options.dispatcherContext);
+    return new options.mockActionContextClass(options.dispatcherContext);
 };

--- a/utils/createMockComponentContext.js
+++ b/utils/createMockComponentContext.js
@@ -5,37 +5,16 @@
 'use strict';
 
 var dispatchr = require('dispatchr');
-var createMockActionContext = require('./createMockActionContext');
-function noop () {}
-
-function MockComponentContext (dispatcherContext) {
-    this.dispatcherContext = dispatcherContext;
-    this.executeActionCalls = [];
-    this.getStore = this.getStore.bind(this);
-    this.executeAction = this.executeAction.bind(this);
-}
-
-MockComponentContext.prototype.getStore = function (name) {
-    return this.dispatcherContext.getStore(name);
-};
-
-MockComponentContext.prototype.executeAction = function (action, payload) {
-    this.executeActionCalls.push({
-        action: action,
-        payload: payload
-    });
-    action(createMockActionContext({
-        dispatcherContext: this.dispatcherContext
-    }), payload, noop);
-};
+var MockComponentContextClass = require('./MockComponentContext');
 
 module.exports = function createMockComponentContext(options) {
     options = options || {};
+    options.mockComponentContextClass = options.mockComponentContextClass || MockComponentContextClass;
     options.stores = options.stores || [];
     options.dispatcher = options.dispatcher || dispatchr.createDispatcher({
         stores: options.stores
     });
     options.dispatcherContext = options.dispatcherContext || options.dispatcher.createContext();
 
-    return new MockComponentContext(options.dispatcherContext);
+    return new options.mockComponentContextClass(options.dispatcherContext);
 };


### PR DESCRIPTION
This makes it easy to extend the mock contexts for testing custom plugin functionality.

@redonkulus @mridgway 