### PR TITLE
Set fallback value for contextPlugin

### DIFF
--- a/lib/Fluxible.js
+++ b/lib/Fluxible.js
@@ -55,7 +55,7 @@ Fluxible.prototype.createContext = function createContext(options) {
     // Plug context with app plugins that implement plugContext method
     this._plugins.forEach(function eachPlugin(plugin) {
         if (plugin.plugContext) {
-            var contextPlugin = plugin.plugContext(options, context, self);
+            var contextPlugin = plugin.plugContext(options, context, self) || {};
             contextPlugin.name = contextPlugin.name || plugin.name;
             context.plug(contextPlugin);
         }

--- a/tests/unit/lib/Fluxible.js
+++ b/tests/unit/lib/Fluxible.js
@@ -78,6 +78,15 @@ describe('Fluxible', function () {
                 app.plug({});
             }).to.throw();
         });
+        it('should not throw when plugContext does not return an object', function () {
+            expect(function () {
+                app.plug({
+                    name: 'OnlyPlugContextPlugin',
+                    plugContext: function () {}
+                });
+                context = app.createContext();
+            }).not.to.throw();
+        });
         it('should provide access to the plugin instance', function () {
             expect(app.getPlugin(pluginInstance.name)).to.equal(pluginInstance);
         });


### PR DESCRIPTION
This PR adds a fallback value when contextPlugin is created, so it'll default to an empty object.

The use-case for this is that I'm toying around with the idea of moving my bootstrap logic into a plugin, since it's pretty similar in both of my server and client entry points. When `plugContext`gets called, it'll add `bootstrap` to the context, and likely tweaking some values based on the options it receives.

If you think it's better to keep current behavior I'm fine with that, since I can just return an empty object from my plugin, and I'm not even sure if it's *actually* a good idea to do this, I'm just sorta experimenting.

As an aside, this is my first PR from 35,000 feet in the air :D. 