### PR TITLE
Async server-side rendering: Add `storesLoaded` method to FluxibleContext; server.js can use this method to allow all actions to complete before rendering.

### DIFF
--- a/lib/FluxibleContext.js
+++ b/lib/FluxibleContext.js
@@ -35,6 +35,9 @@ function FluxContext(options) {
     this._actionContext = null;
     this._componentContext = null;
     this._storeContext = null;
+
+    // Book-keeping for actions
+    this.executingActions = 0;
 }
 
 // Provied a way to override Promise only for FluxContext
@@ -137,16 +140,16 @@ FluxContext.prototype.executeAction = function executeAction(action, payload, do
         });
     });
 
-    if (done) {
-        executeActionPromise
-            .then(function(result) {
-                // Ensures that errors in callback are not swallowed by promise
-                setImmediate(done, null, result);
-            }, function (err) {
-                // Ensures that errors in callback are not swallowed by promise
-                setImmediate(done, err);
-            });
-    }
+    executeActionPromise
+      .then(function(result) {
+          this.executingActions--;
+          // Ensures that errors in callback are not swallowed by promise
+          setImmediate(done || function () {}, null, result);
+      }.bind(this), function (err) {
+          this.executingActions--;
+          // Ensures that errors in callback are not swallowed by promise
+          setImmediate(done || function () {}, err);
+      }.bind(this));
 
     return executeActionPromise;
 };
@@ -205,7 +208,8 @@ FluxContext.prototype.getActionContext = function getActionContext() {
     var actionContext = {
         dispatch: this._dispatcher.dispatch.bind(this._dispatcher),
         executeAction: this.executeAction.bind(this),
-        getStore: this._dispatcher.getStore.bind(this._dispatcher)
+        getStore: this._dispatcher.getStore.bind(this._dispatcher),
+        storesLoaded: this.storesLoadedRecursive.bind(this)
     };
 
     self._plugins.forEach(function pluginsEach(plugin) {
@@ -218,6 +222,42 @@ FluxContext.prototype.getActionContext = function getActionContext() {
     self._actionContext = actionContext;
 
     return self._actionContext;
+};
+
+/**
+ * Verify that all stores are loaded; render component; make sure all stores are loaded again.
+ * @method storesLoadedRecursive
+ * @param {Function} Callback once all stores have completed loading, including after a render cycle.
+ */
+FluxContext.prototype.storesLoadedRecursive = function storesLoadedRecursive(cb, iterations) {
+    var maxIterations = 5;
+
+    iterations = iterations || 0;
+
+    if (iterations > maxIterations) {
+        debug('bailing out after ' + iterations + ' iterations');
+        return cb();
+    }
+
+    // Attempt to render - this could trigger more actions that we want to respond to before
+    //  sending HTML to the client.
+    React.renderToString(this.createElement());
+
+    return setImmediate(function () {
+        return this._dispatcher.storesLoaded(function (err, stabilized) {
+            // Increment iteration counter to make sure that we don't get stuck in an infinite loop.
+            // If we know that we are currently executing an act, we penalize that less since we don't actually
+            // get a callback for actions executing/finishing in this class, only stores being marked loaded by the dispatcher.
+            var incrementCounter = (this.executingActions > 0 ? 0.1 : (stabilized ? 1 : 0));
+            if (incrementCounter !== 0) {
+                return setImmediate(function () {
+                    return this.storesLoadedRecursive(cb, iterations+incrementCounter);
+                }.bind(this))
+            }
+
+            return cb();
+        }.bind(this));
+    }.bind(this));
 };
 
 /**


### PR DESCRIPTION
Hey all, there seems to be some confusion online as to how to make React fully isomorphic (including fetching any data necessary), and this is my initial attempt. I'm trying to figure out how to fetch data asynchronously and make sure that HTML is fully inflated before rendering server-side using Fluxible. I was running into an issue where actions were in-flight but were not yet in `currentAction` of the dispatcher context; because of this race condition, pages were being rendered without any actual data. I added some simple book-keeping to FluxibleContext and an optional method that users can hook into to get a callback once all data is loaded. 

In my `server.js`, my `server.use` now contains this block:

```
        context.getActionContext().storesLoaded(function () {
            debug('Exposing context state');
            const exposed = 'window.App=' + serialize(app.dehydrate(context)) + ';';

            debug('Rendering Application component into html');
            const html = React.renderToStaticMarkup(htmlComponent({
                assets,
                context: context.getComponentContext(),
                state: exposed,
                markup: React.renderToString(context.createElement())
            }));

            debug('Sending markup');
            res.type('html');
            res.write('<!DOCTYPE html>' + html);
            res.end();
        });
```

I'm fairly new to React so I'm somewhat concerned I need this because of some anti-pattern I'm using, but Fluxible's documentation and various articles online didn't help much. So, I'd love feedback. Thanks! 