### PR TITLE
Fixed a typo  :

### DIFF
--- a/docs/guides/bringing-flux-to-the-server.md
+++ b/docs/guides/bringing-flux-to-the-server.md
@@ -301,7 +301,7 @@ var server = express();
 var Dispatcher = require('./lib/dispatcher');
 
 server.get('/', function (req, res, next) {
-    var dispatcher = new Dispatchr();
+    var dispatcher = new Dispatcher();
 
     // Now the action needs access to the dispatcher too
     showMessages(dispatcher, {}, function () {


### PR DESCRIPTION
On line 304.

// lib/dispatcher.js
var Dispatcher = require('dispatchr')();
// server.js
var dispatcher = new Dispatchr();

to
// server.js
var dispatcher = new Dispatcher();