### PR TITLE
Moved FluxibleContext.createElement to addons as createElementWithContext

### DIFF
--- a/addons/createElementWithContext.js
+++ b/addons/createElementWithContext.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+
+var React = require('react');
+var FluxibleComponent = require('./FluxibleComponent');
+var objectAssign = require('object-assign');
+
+/**
+ * Creates an instance of the app level component with given props and a proper component
+ * context.
+ * @param {FluxibleContext} fluxibleContext
+ * @param {Object} props
+ * @return {ReactElement}
+ */
+module.exports = function createElement(fluxibleContext, props) {
+    var Component = fluxibleContext.getComponent();
+    if (!Component) {
+        throw new Error('A component was not specified.');
+    }
+    if ('ContextProvider' === Component.displayName) {
+        return React.createElement(Component, objectAssign({}, {
+            context: fluxibleContext.getComponentContext()
+        }, props));
+    }
+    var componentInstance = React.createElement(Component, props);
+    return React.createElement(FluxibleComponent, {
+        context: fluxibleContext.getComponentContext()
+    }, componentInstance);
+};

--- a/lib/Fluxible.js
+++ b/lib/Fluxible.js
@@ -48,8 +48,7 @@ Fluxible.Promise = PromiseLib;
 Fluxible.prototype.createContext = function createContext(options) {
     var self = this;
     options = options || {};
-    options.app = self;
-    var context = new FluxibleContext(options);
+    var context = new FluxibleContext(self);
 
     // Plug context with app plugins that implement plugContext method
     this._plugins.forEach(function eachPlugin(plugin) {
@@ -125,7 +124,7 @@ Fluxible.prototype.getPlugin = function (pluginName) {
 /**
  * Getter for the top level react component for the application
  * @method getComponent
- * @returns {Object}
+ * @returns {ReactComponent}
  */
 Fluxible.prototype.getComponent = function getComponent() {
     return this._component;

--- a/lib/FluxibleContext.js
+++ b/lib/FluxibleContext.js
@@ -9,21 +9,17 @@ var objectAssign = require('object-assign');
 var isPromise = require('is-promise');
 var PromiseLib = global.Promise || require('es6-promise').Promise;
 var React = require('react');
-var FluxibleComponent = require('../addons/FluxibleComponent');
+var createElement = require('../addons/createElementWithContext');
 require('setimmediate');
 
 /**
  * A request or browser-session context
  * @class FluxibleContext
- * @param {Object} options
- * @param {Fluxible} options.app The Fluxible instance used to create the context
+ * @param {Fluxible} app The Fluxible instance used to create the context
  * @constructor
  */
-function FluxContext(options) {
-    options = options || {};
-
-    // Options
-    this._app = options.app;
+function FluxContext(app) {
+    this._app = app;
 
     // To be created on demand
     this._dispatcher = null;
@@ -44,34 +40,25 @@ FluxContext.Promise = PromiseLib;
  * Creates an instance of the app level component with given props and a proper component
  * context.
  * @param {Object} props
+ * @deprecated
  * @return {ReactElement}
  */
 FluxContext.prototype.createElement = function createElement(props) {
-    var component = this._app.getComponent();
-    if (!component) {
-        throw new Error('A component was not specified.');
+    if (process.env.NODE_ENV !== 'production') {
+        console.warn('`context.createElement(props)` has been moved out of ' +
+            'Fluxible to fluxible-addons. This can be called using ' +
+            '`require(\'fluxible-addons\').createElement(context, props)`');
     }
-    if ('ContextProvider' === component.displayName) {
-        return React.createElement(component, objectAssign({}, {
-            context: this.getComponentContext()
-        }, props));
-    }
-    var componentInstance;
-    if (!component.hasOwnProperty('prototype')) {
-        // TODO: remove factory support
-        if ('production' !== process.env.NODE_ENV) {
-            console.warn('When using context.createFactory(), it is no longer ' +
-                'necessary to wrap your component with `React.createFactory` when ' +
-                'instantiating Fluxible. Support for factories will be removed ' +
-                'in the next version of Fluxible.');
-        }
-        componentInstance = component(props);
-    } else {
-        componentInstance = React.createElement(component, props);
-    }
-    return React.createElement(FluxibleComponent, {
-        context: this.getComponentContext()
-    }, componentInstance);
+    return createElement(this, props);
+};
+
+/**
+ * Getter for the app's component. Pass through to the Fluxible instance.
+ * @method getComponent
+ * @returns {ReactComponent}
+ */
+FluxContext.prototype.getComponent = function getComponent() {
+    return this._app.getComponent();
 };
 
 /**

--- a/tests/unit/lib/FluxibleContext.js
+++ b/tests/unit/lib/FluxibleContext.js
@@ -9,6 +9,7 @@ var FluxibleContext = require('../../../lib/FluxibleContext');
 var isPromise = require('is-promise');
 var React = require('react');
 var createStore = require('dispatchr/addons/createStore');
+var createElementWithContext = require('../../../addons/createElementWithContext')
 var domain = require('domain');
 
 // Fix for https://github.com/joyent/node/issues/8648
@@ -46,7 +47,7 @@ describe('FluxibleContext', function () {
             });
             context = app.createContext();
 
-            React.renderToString(context.createElement({foo: 'bar'}));
+            React.renderToString(createElementWithContext(context, {foo: 'bar'}));
         });
         it('should receive the correct props and context when using contextProvider', function (done) {
             var Component = React.createClass({
@@ -69,7 +70,7 @@ describe('FluxibleContext', function () {
             });
             context = app.createContext();
 
-            React.renderToString(context.createElement({foo: 'bar'}));
+            React.renderToString(createElementWithContext(context, {foo: 'bar'}));
         });
         it('should receive the correct props and context if passed factory', function (done) {
             var Component = React.createClass({
@@ -91,7 +92,7 @@ describe('FluxibleContext', function () {
             });
             context = app.createContext();
 
-            React.renderToString(context.createElement({foo: 'bar'}));
+            React.renderToString(createElementWithContext(context, {foo: 'bar'}));
         });
     });
 


### PR DESCRIPTION
This is the first step to making Fluxible not depend on React directly. This is the only method within core that uses React. By moving this to addons, we can split addons to a separate package and core will work independently with any framework (React/React Native/etc.).