### PR TITLE
Allow rehydration with empty object

### DIFF
--- a/lib/Fluxible.js
+++ b/lib/Fluxible.js
@@ -174,6 +174,7 @@ Fluxible.prototype.dehydrate = function dehydrate(context) {
  */
 Fluxible.prototype.rehydrate = function rehydrate(obj, callback) {
     debug('rehydrate', obj);
+    obj = obj || {};
     var self = this;
     var Promise = Fluxible.Promise;
     obj.plugins = obj.plugins || {};
@@ -198,7 +199,7 @@ Fluxible.prototype.rehydrate = function rehydrate(obj, callback) {
 
     var context = self.createContext();
     var rehydratePromise = Promise.all(pluginTasks).then(function rehydratePluginTasks() {
-        return context.rehydrate(obj.context);
+        return context.rehydrate(obj.context || {});
     });
 
     if (callback) {

--- a/tests/unit/lib/Fluxible.js
+++ b/tests/unit/lib/Fluxible.js
@@ -60,6 +60,22 @@ describe('Fluxible', function () {
         });
     });
 
+    describe('rehydrate', function () {
+        it('should rehydrate with empty object', function (done) {
+            var newApp = new Fluxible({
+                component: Component
+            });
+            newApp.rehydrate({}, function (err, newContext) {
+                if (err) {
+                    done(err);
+                    return;
+                }
+                expect(newContext).to.be.an('object');
+                done();
+            });
+        });
+    });
+
     describe('plugins', function () {
         var testPlugin = require('../../fixtures/plugins/TestApplicationPlugin'),
             testPluginSync = require('../../fixtures/plugins/TestApplicationPluginSync'),


### PR DESCRIPTION
Safeguards rehydration from throwing undefined errors.