### PR TITLE
Add getStore to context class

### DIFF
--- a/lib/FluxibleContext.js
+++ b/lib/FluxibleContext.js
@@ -62,6 +62,18 @@ FluxContext.prototype.getComponent = function getComponent() {
 };
 
 /**
+ * Getter for store from dispatcher
+ * @method getStore
+ * @returns {Object}
+ */
+FluxContext.prototype.getStore = function getStore(store) {
+    if (!this._dispatcher) {
+        this._initializeDispatcher();
+    }
+    return this._dispatcher.getStore(store);
+};
+
+/**
  * Provides plugin mechanism for adding application level settings that are persisted
  * between server/client and also modification of the FluxibleContext
  * @method plug

--- a/tests/unit/lib/FluxibleContext.js
+++ b/tests/unit/lib/FluxibleContext.js
@@ -96,6 +96,22 @@ describe('FluxibleContext', function () {
         });
     });
 
+    describe('getStore', function () {
+        it('should provide access to registered store instance', function () {
+            var store = createStore({
+                storeName: 'TestStore'
+            });
+
+            app.registerStore(store);
+
+            var context = app.createContext();
+
+            var storeInstance = context.getStore(store);
+            expect(storeInstance).to.be.an('object');
+            expect(storeInstance.constructor.storeName).to.equal(store.storeName);
+        });
+    });
+
     describe('actionContext', function () {
         var actionContext;
         var actionCalls;


### PR DESCRIPTION
Allows easier access to stores from client or server bootstrap files. `context.getActionContext().getStore()` -> `context.getStore()`.