### PR TITLE
add action name info error object while execute action

### DIFF
--- a/docs/api/FluxibleContext.md
+++ b/docs/api/FluxibleContext.md
@@ -45,6 +45,7 @@ Parameters:
 
  * `action`: A function that takes three parameters: `actionContext`, `payload`, `done`
  * `payload`: the action payload
+ * `payload.errorInfo`: when error happens, `errorInfo` will be appended to the error object as `error.info`
  * `done`: optional callback to call when the action has been completed. Receives error as the first parameter and result as the second.
 
 Returns:

--- a/lib/FluxibleContext.js
+++ b/lib/FluxibleContext.js
@@ -99,12 +99,27 @@ FluxContext.prototype.plug = function (plugin) {
 };
 
 /**
+ * Get action name, compatible with all browsers
+ * @param {Function} action
+ * @return {String} action display name
+ */
+function getActionName (action) {
+    var actionName = action.displayName || action.name;
+    if (!actionName) {
+        var match = action.toString().match(/^function\s*([^\s(]+)/);
+        actionName = match && match[1];
+    }
+    return actionName;
+};
+
+/**
  * Executes an action, and calls either resolve or reject based on the callback result
  * This is extracted from FluxContext.prototype.executeAction to prevent this method de-optimising
  * due to the try/catch
  * @param {Object} context FluxContext object
  * @param {Function} action Action to call
  * @param {Object} payload Payload for the action
+ * @param {Object} payload.errorInfo error information, will be appended to the err object
  * @param {Function} resolve function to call on success
  * @param {Function} reject function to call on failure
  * @private
@@ -112,6 +127,9 @@ FluxContext.prototype.plug = function (plugin) {
 function executeActionInternal(context, action, payload, resolve, reject) {
     var syncResult = action(context.getActionContext(), payload, function (err, result) {
         if (err) {
+            if (payload.errorInfo) {
+                err.info = payload.errorInfo;
+            }
             reject(err);
         } else {
             resolve(result);
@@ -139,7 +157,7 @@ function executeActionInternal(context, action, payload, resolve, reject) {
 FluxContext.prototype.executeAction = function executeAction(action, payload, done) {
     var self = this;
     payload = (undefined !== payload) ? payload : {};
-    var displayName = action.displayName || action.name;
+    var displayName = getActionName(action);
     var Promise = FluxContext.Promise;
     if (process.env.NODE_ENV !== 'production') {
         if (this._dispatcher && this._dispatcher.currentAction) {
@@ -159,6 +177,9 @@ FluxContext.prototype.executeAction = function executeAction(action, payload, do
             try {
                 executeActionInternal(self, action, payload, resolve, reject);
             } catch (err) {
+                if (payload.errorInfo) {
+                    err.info = payload.errorInfo;
+                }
                 reject(err);
             }
         });

--- a/tests/unit/lib/FluxibleContext.js
+++ b/tests/unit/lib/FluxibleContext.js
@@ -210,8 +210,9 @@ describe('FluxibleContext', function () {
                 var action = function (context, payload, callback) {
                     callback(err);
                 };
-                actionContext.executeAction(action, {})
+                actionContext.executeAction(action, {errorInfo: {foo: 'bar'}})
                 .catch(function (callbackError) {
+                    expect(callbackError.info).to.eql({foo: 'bar'});
                     expect(callbackError).to.equal(err);
                     done();
                 });
@@ -266,11 +267,16 @@ describe('FluxibleContext', function () {
                     });
                     throw err;
                 };
-                var payload = {};
+                var payload = {
+                    errorInfo: {
+                        foo: 'bar'
+                    }
+                };
                 actionContext.executeAction(action, payload)
                 .catch(function (actionError) {
                         try {
                             expect(actionError).to.equal(err);
+                            expect(actionError.info).to.eql({foo: 'bar'});
                             expect(actionCalls.length).to.equal(1);
                             expect(actionCalls[0].context).to.equal(actionContext);
                             expect(actionCalls[0].payload).to.equal(payload);
@@ -600,5 +606,4 @@ describe('FluxibleContext', function () {
             expect(isPromise(rehydratePromise));
         });
     });
-
 });


### PR DESCRIPTION
1. this might be useful when we want to integrate `componentActionHandler`, as long as payload.errorInfo is defined, append `info` to error object for users to decide how to handle the error.

2. `action.displayName || action.name` might not work with IE, add some code to be compatible with IE

@mridgway @redonkulus @lingyan 