### PR TITLE
Adds a safe global check

### DIFF
--- a/lib/Fluxible.js
+++ b/lib/Fluxible.js
@@ -5,7 +5,7 @@
 'use strict';
 
 var debug = require('debug')('Fluxible');
-var PromiseLib = global.Promise || require('es6-promise').Promise;
+var PromiseLib = (global && global.Promise) || require('es6-promise').Promise;
 var isPromise = require('is-promise');
 var FluxibleContext = require('./FluxibleContext');
 var dispatchr = require('dispatchr');

--- a/lib/FluxibleContext.js
+++ b/lib/FluxibleContext.js
@@ -6,7 +6,7 @@
 
 var debug = require('debug')('Fluxible:Context');
 var isPromise = require('is-promise');
-var PromiseLib = global.Promise || require('es6-promise').Promise;
+var PromiseLib = (global && global.Promise) || require('es6-promise').Promise;
 var React = require('react');
 var createElementWithContext = require('fluxible-addons-react/createElementWithContext');
 require('setimmediate');


### PR DESCRIPTION
Checks if the global object exists before try to access the Promise object in it.
This creates a `Cannot read property 'Promise' of undefined` TypeError when trying to load browserify and webpack modules at the same time.
@redonkulus 