### PR TITLE
[docs] prebind this.onClick in constructor of ES6 Class

### DIFF
--- a/docs/api/Actions.md
+++ b/docs/api/Actions.md
@@ -64,6 +64,7 @@ import myAction from './myAction';
 class MyComponent extends React.Component {
     constructor (props) {
         super(props);
+        this.onClick = this.onClick.bind(this);
     }
     onClick (e) {
         this.context.executeAction(myAction, {});


### PR DESCRIPTION
ES6 `class` syntax for components does not have autobinding lie with `React.createClass`

explicitly prebinding method in the constructor as shown [here](https://github.com/facebook/react/blob/master/docs/_posts/2015-01-27-react-v0.13.0-beta-1.md#autobinding)

resolves #253