### PR TITLE
Correctly bind executeAction to newactionContext

### DIFF
--- a/lib/FluxibleContext.js
+++ b/lib/FluxibleContext.js
@@ -148,14 +148,13 @@ function executeActionProxy(context, actionContext, action, payload, done) {
      * Use the `displayName` property on your actions for better
      * action tracing when your code gets minified in prod.
      * One action can execute multiple actions, so we need to create a shallow
-     * clone with a new stack & new id every time getActionContext is called.
-     * We expect next to be defined in most cases (by callAction)
-     * unless the user calls `getActionContext` manually.
+     * clone with a new stack & new id every time a newActionContext is created.
      */
-    var newActionContext = Object.assign({}, context.getActionContext(), {
+    var newActionContext = Object.assign({}, actionContext, {
         stack: (actionContext.stack || []).concat([displayName]),
         rootId: (actionContext.rootId) || generateUUID()
     });
+    newActionContext.executeAction = newActionContext.executeAction.bind(newActionContext);
     if (debug.enabled) {
         debug('Executing action ' + newActionContext.stack.join('.') + ' with payload', payload);
     }

--- a/tests/unit/lib/FluxibleContext.js
+++ b/tests/unit/lib/FluxibleContext.js
@@ -106,7 +106,8 @@ describe('FluxibleContext', function () {
                             context.executeAction(actionThree, payload, function actionOneThirdcallback () {
                                 cb();
                             });
-                        }
+                        },
+                        async.apply(context.executeAction, actionFour, payload)
                     ], function (err) {
                         callback(err)
                     });
@@ -128,9 +129,17 @@ describe('FluxibleContext', function () {
                     callback();
                 };
                 actionThree.displayName = 'Three';
+                var actionFour = function (context, payload, callback) {
+                    actionCalls.push({
+                        context: context,
+                        payload: payload
+                    });
+                    callback();
+                };
+                actionFour.displayName = 'Four';
                 var payload = {};
                 var callback = function () {
-                    expect(actionCalls.length).to.equal(4);
+                    expect(actionCalls.length).to.equal(5);
                     expect(actionCalls[0].context).to.contain.keys(Object.keys(actionContext));
                     expect(actionCalls[0].context).to.contain.keys(['rootId','stack']);
                     var firstId = actionCalls[0].context.rootId;
@@ -151,6 +160,11 @@ describe('FluxibleContext', function () {
                     expect(actionCalls[3].context.rootId).to.equal(firstId);
                     expect(actionCalls[3].context.stack.join('.')).to.equal('One.Three');
                     expect(actionCalls[3].payload).to.equal(payload);
+                    expect(actionCalls[4].context).to.contain.keys(Object.keys(actionContext));
+                    expect(actionCalls[4].context).to.contain.keys(['rootId','stack']);
+                    expect(actionCalls[4].context.rootId).to.equal(firstId);
+                    expect(actionCalls[4].context.stack.join('.')).to.equal('One.Four');
+                    expect(actionCalls[4].payload).to.equal(payload);
                     done();
                 };
                 actionContext = context.getActionContext();


### PR DESCRIPTION
@mridgway @kaesonho 

`executeAction` is throwing `Cannot read property 'stack' of null` when `context.executeAction` was called via async:
```
async.apply(context.executeAction, myAction, payload)
```

This would also happen if a user did something like this as @mridgway pointed out:
```js
var exec = context.executeAction;
exec(myAction, payload);
```