### PR TITLE
pin fluxible-addons-react to 0.1 to make sure react dep is met, since…

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "debug": "^2.0.0",
     "dispatchr": "^0.3.1",
     "es6-promise": "^3.0.2",
-    "fluxible-addons-react": "*",
+    "fluxible-addons-react": "^0.1.8",
     "is-promise": "^2.0.0",
     "object-assign": "^4.0.1",
     "setimmediate": "^1.0.2"


### PR DESCRIPTION
… fluxible-addons-react@0.2 (the latest on npm) wants react-0.14

This PR is for fluxible@0.5.x

@mridgway 