### PR TITLE
Make npm run dev work with windows

### DIFF
--- a/packages/generator-fluxible/app/templates/package.json
+++ b/packages/generator-fluxible/app/templates/package.json
@@ -5,7 +5,7 @@
   "main": "start.js",
   "scripts": {
     "build": "webpack & webpack --config webpack.config.production.js",
-    "dev": "node webpack-dev-server.js & PORT=3001 nodemon start.js -e js,jsx",
+    "dev": "node webpack-dev-server.js",
     "lint": "eslint ./*.js ./**/*.js",
     "start": "node start.js"
   },
@@ -36,6 +36,7 @@
     "json-loader": "^0.5.1",
     "nodemon": "^1.2.1",
     "react-hot-loader": "^1.2.8",
+    "shelljs": "^0.5.3",
     "webpack": "^1.4.12",
     "webpack-dev-server": "^1.6.5"
   }

--- a/packages/generator-fluxible/app/templates/webpack-dev-server.js
+++ b/packages/generator-fluxible/app/templates/webpack-dev-server.js
@@ -11,5 +11,7 @@ new WebpackDevServer(webpack(config), {
         '*': { target: 'http://localhost:3001' }
     }
 }).listen(3000, function () {
+    shell.env.PORT = shell.env.PORT || 3001;
+    shell.exec('"./node_modules/.bin/nodemon" start.js -e js,jsx', function () {});
     console.log('Webpack Dev Server listening on port 3000');
 });


### PR DESCRIPTION
Running the server from within the webpack-dev-server script using shelljs. Tested with my Windows 8.1 machine.

@hackhat and @xiongxin, could you test this method out with your apps locally? If confirmed to work correctly for you, I will merge and release.