### PR TITLE
resolve #294, MockActionContext Promise support

### DIFF
--- a/packages/fluxible/tests/unit/utils/createMockActionContext.js
+++ b/packages/fluxible/tests/unit/utils/createMockActionContext.js
@@ -1,0 +1,100 @@
+/* jshint newcap:false */
+/* global describe, it, beforeEach, after */
+
+'use strict';
+
+var expect = require('chai').expect;
+var mockery = require('mockery');
+var createMockActionContext = require('../../../utils').createMockActionContext;
+
+describe('createMockActionContext', function () {
+
+    describe('instance', function () {
+        var context;
+
+        beforeEach(function () {
+            context = createMockActionContext();
+        });
+
+        it('should have executeActionCalls property', function () {
+            expect(context).to.have.property('executeActionCalls').that.is.an('array').and.empty;
+        });
+
+        it('should have dispatchCalls property', function () {
+            expect(context).to.have.property('dispatchCalls').that.is.an('array').and.empty;
+        });
+
+        it('should have dispatcherContext property', function () {
+            expect(context).to.have.property('dispatcherContext').that.is.an('object');
+        });
+
+        describe('#getStore', function () {
+            it('should delegate to the dispatcher getStore method', function () {
+                expect(context).to.have.property('getStore');
+            });
+        });
+
+        describe('#executeAction', function () {
+            var mockPayload = {
+                foo: 'bar',
+                baz: 'fubar'
+            };
+
+            function mockAction (ctx, payload, cb) {
+                expect(ctx).to.be.an('object');
+                expect(ctx.dispatch).to.be.a('function');
+                expect(ctx.executeAction).to.be.a('function');
+                expect(payload).to.equal(mockPayload);
+                return cb();
+            }
+
+            function cbResult (done) {
+                return function cb () {
+                    expect(context.executeActionCalls).to.have.length(1);
+
+                    var call = context.executeActionCalls[0];
+                    expect(call).to.have.property('action', mockAction);
+                    expect(call).to.have.property('payload', mockPayload);
+                    return done();
+                }
+            }
+
+            it('should provide an executeAction method', function () {
+                expect(context).to.respondTo('executeAction');
+            });
+
+            it('should execute the action and infer to return a Promise, success', function (done) {
+                context.executeAction(mockAction, mockPayload).then(cbResult(done));
+            });
+
+            it('should execute the action and infer to return a Promise, failure', function (done) {
+                function mockActionFailure (ctx, payload, cb) {
+                    cb(new Error('mock'));
+                }
+
+                context.executeAction(mockActionFailure, mockPayload).then(function() {
+                    done(new Error('should not have resolved successfully'));
+                }).catch(function (error) {
+                    expect(error).to.be.an('Error');
+                    done();
+                });
+            });
+
+            it('should execute the action and infer to NOT return a Promise', function () {
+                var returnValue = 'mock';
+                var result = context.executeAction(mockAction, mockPayload, cbResult(function () {
+                    return returnValue;
+                }));
+                expect(result).to.equal(returnValue);
+            });
+        });
+
+        describe.skip('#dispatch', function () {
+        });
+    });
+
+    after(function() {
+        mockery.deregisterAll();
+        mockery.disable();
+    });
+});

--- a/packages/fluxible/utils/MockActionContext.js
+++ b/packages/fluxible/utils/MockActionContext.js
@@ -3,6 +3,7 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 'use strict';
+var callAction = require('./callAction');
 
 function MockActionContext (dispatcherContext) {
     this.dispatcherContext = dispatcherContext;
@@ -27,7 +28,7 @@ MockActionContext.prototype.executeAction = function (action, payload, callback)
         action: action,
         payload: payload
     });
-    return action(this, payload, callback);
+    return callAction(action, this, payload, callback);
 };
 
 module.exports = MockActionContext;

--- a/packages/fluxible/utils/callAction.js
+++ b/packages/fluxible/utils/callAction.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2014, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+/* global Promise */
+'use strict';
+var isPromise = require('is-promise');
+
+/**
+ * Call an action supporting Promise expectations on invocation.
+ *
+ * If done callback supplied, that indicates non-Promise invocation expectation,
+ * otherwise, Promise invocation.
+ */
+function callAction (action, context, payload, done) {
+  if (done) {
+    return action(context, payload, done);
+  }
+
+  return new Promise(function (resolve, reject) {
+    try {
+      var syncResult = action(context, payload, function (err, result) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(result);
+        }
+      });
+      if (isPromise(syncResult)) {
+        syncResult.then(resolve, reject);
+      } else if (action.length < 3) {
+        resolve(syncResult);
+      }
+    } catch (e) {
+      reject(e);
+    }
+  });
+}
+
+module.exports = callAction;


### PR DESCRIPTION
My idea for #294. (re)Uses the Fluxible callAction idea for MockActionContext. MockComponentContext not needed.