### PR TITLE
Add rootId to MockActionContext

### DIFF
--- a/packages/fluxible/lib/FluxibleContext.js
+++ b/packages/fluxible/lib/FluxibleContext.js
@@ -6,6 +6,8 @@
 
 var debug = require('debug')('Fluxible:Context');
 var isPromise = require('is-promise');
+var generateUUID = require('../utils/generateUUID');
+
 var __DEV__ = process.env.NODE_ENV !== 'production';
 require('setimmediate');
 
@@ -230,16 +232,6 @@ FluxContext.prototype.getActionContext = function getActionContext() {
 
     return self._actionContext;
 };
-
-/*
- * Generate a GUID for keeping track of a
- * transaction of actions and dispatches.
- * Reference: https://github.com/facebook/react/blob/a48ffb04dcfe4d6f832207618a8b39e3034bd413/src/renderers/dom/server/ServerReactRootIndex.js
- */
-var GLOBAL_UUID_MAX = Math.pow(2, 53);
-function generateUUID () {
-    return Math.ceil(Math.random() * GLOBAL_UUID_MAX);
-}
 
 /**
  * Returns the context for action controllers

--- a/packages/fluxible/tests/unit/utils/createMockActionContext.js
+++ b/packages/fluxible/tests/unit/utils/createMockActionContext.js
@@ -28,6 +28,10 @@ describe('createMockActionContext', function () {
             expect(context).to.have.property('dispatcherContext').that.is.an('object');
         });
 
+        it('should have rootId property', function () {
+            expect(context).to.have.property('rootId').that.is.a('number');
+        });
+
         describe('#getStore', function () {
             it('should delegate to the dispatcher getStore method', function () {
                 expect(context).to.have.property('getStore');

--- a/packages/fluxible/utils/MockActionContext.js
+++ b/packages/fluxible/utils/MockActionContext.js
@@ -4,11 +4,13 @@
  */
 'use strict';
 var callAction = require('./callAction');
+var generateUUID = require('./generateUUID');
 
 function MockActionContext (dispatcherContext) {
     this.dispatcherContext = dispatcherContext;
     this.executeActionCalls = [];
     this.dispatchCalls = [];
+    this.rootId = generateUUID();
 }
 
 MockActionContext.prototype.getStore = function (name) {

--- a/packages/fluxible/utils/generateUUID.js
+++ b/packages/fluxible/utils/generateUUID.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+'use strict';
+
+/*
+ * Generate a GUID for keeping track of a
+ * transaction of actions and dispatches.
+ * Reference: https://github.com/facebook/react/blob/a48ffb04dcfe4d6f832207618a8b39e3034bd413/src/renderers/dom/server/ServerReactRootIndex.js
+ */
+var GLOBAL_UUID_MAX = Math.pow(2, 53);
+
+module.exports = function generateUUID () {
+    return Math.ceil(Math.random() * GLOBAL_UUID_MAX);
+}


### PR DESCRIPTION
This PR extracts the `generateUUID` function into its own util and adds a `rootId` to `MockActionContext`