### PR TITLE
Checks if the action is a function for utils/callAction.js

### DIFF
--- a/packages/fluxible/utils/callAction.js
+++ b/packages/fluxible/utils/callAction.js
@@ -13,6 +13,10 @@ var isPromise = require('is-promise');
  * otherwise, Promise invocation.
  */
 function callAction (action, context, payload, done) {
+  if (typeof action !== 'function') {
+    throw new Error('An action need to be a function');
+  }
+
   if (done) {
     return action(context, payload, done);
   }


### PR DESCRIPTION
Emulates the DEV behavior of the FluxibleContext executeAction since this helper is mainly use for tests.
The executeAction should thrown a error if the action is not a function.