### PR TITLE
Update Components.md

### DIFF
--- a/packages/fluxible/docs/api/Components.md
+++ b/packages/fluxible/docs/api/Components.md
@@ -174,9 +174,9 @@ describe('TestComponent', function () {
                 }
             });
             // Wrap with context provider and store connector
-            TestComponent = provideContext(connectToStores(TestComponent, [FooStore], function (stores) {
+            TestComponent = provideContext(connectToStores(TestComponent, [FooStore], function (context, props) {
                 return {
-                    foo: stores.FooStore.getFoo()
+                    foo: context.getStore(FooStore).getFoo()
                 };
             }));
             done();


### PR DESCRIPTION
TestComponent's connectToStores state getter is trying to access FooStore. connectToStore no longer passes the stores to the state getter. The state getter signature is now (context, props) and you should access the store using `context.getStore(FooStore)`.