### PR TITLE
Add event emitters to executeAction for debugging

### DIFF
--- a/packages/fluxible/package.json
+++ b/packages/fluxible/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "debug": "^2.0.0",
     "dispatchr": "^0.3.1",
+    "eventemitter3": "^1.0.0",
+    "inherits": "^2.0.1",
     "is-promise": "^2.0.0",
     "setimmediate": "^1.0.2"
   },

--- a/packages/fluxible/tests/unit/lib/FluxibleContext.js
+++ b/packages/fluxible/tests/unit/lib/FluxibleContext.js
@@ -443,6 +443,33 @@ describe('FluxibleContext', function () {
 
                 });
             });
+            it('should emit start and end events', (done) => {
+                var events = [];
+                var onStart = context.on('executeAction.start', (params) => {
+                    events.push({ name: 'executeAction.start', params });
+                });
+                var onEnd = context.on('executeAction.end', (params) => {
+                    events.push({ name: 'executeAction.end', params });
+                });
+                var action = function fooAction(context, payload, callback) {
+                    callback();
+                };
+                var callback = function () {
+                    context.removeListener('executeAction.start', onStart);
+                    context.removeListener('executeAction.end', onEnd);
+                    expect(events.length).to.equal(2);
+                    expect(events[0].name).to.equal('executeAction.start');
+                    expect(events[0].params.name).to.equal(action.name);
+                    expect(events[0].params.rootId).to.not.equal(undefined);
+                    expect(events[0].params.stack.length).to.equal(1);
+                    expect(events[1].name).to.equal('executeAction.end');
+                    expect(events[1].params.name).to.equal(action.name);
+                    expect(events[1].params.rootId).to.not.equal(undefined);
+                    expect(events[1].params.stack.length).to.equal(1);
+                    done();
+                };
+                actionContext.executeAction(action, {}, callback);
+            });
         });
     });
 
@@ -578,6 +605,7 @@ describe('FluxibleContext', function () {
                 var d = domain.create();
                 d.on('error', function (e) {
                     expect(e).to.equal(actionError);
+                    d.dispose();
                     done();
                 });
                 d.run(function () {
@@ -594,6 +622,33 @@ describe('FluxibleContext', function () {
                     var componentContext2 = context2.getComponentContext();
                     componentContext2.executeAction(action, {});
                 });
+            });
+            it('should emit start and end events', (done) => {
+                var events = [];
+                var onStart = context.on('executeAction.start', (params) => {
+                    events.push({ name: 'executeAction.start', params });
+                });
+                var onEnd = context.on('executeAction.end', (params) => {
+                    events.push({ name: 'executeAction.end', params });
+                });
+                var action = function fooAction(context, payload, callback) {
+                    callback();
+                };
+                componentContext.executeAction(action, {});
+                setTimeout(function () {
+                    context.removeListener('executeAction.start', onStart);
+                    context.removeListener('executeAction.end', onEnd);
+                    expect(events.length).to.equal(2);
+                    expect(events[0].name).to.equal('executeAction.start');
+                    expect(events[0].params.name).to.equal(action.name);
+                    expect(events[0].params.rootId).to.not.equal(undefined);
+                    expect(events[0].params.stack.length).to.equal(1);
+                    expect(events[1].name).to.equal('executeAction.end');
+                    expect(events[1].params.name).to.equal(action.name);
+                    expect(events[1].params.rootId).to.not.equal(undefined);
+                    expect(events[1].params.stack.length).to.equal(1);
+                    done();
+                }, 10);
             });
         });
     });


### PR DESCRIPTION
This allows for debugging all execute actions that pass through the Fluxible context. Eventually we should add the same ability for `dispatch` calls, which would be part of dispatchr.