### PR TITLE
Convert createClass calls to React.Component classes where possible; Remove autobinding otherwise

### DIFF
--- a/packages/fluxible-addons-react/FluxibleComponent.js
+++ b/packages/fluxible-addons-react/FluxibleComponent.js
@@ -5,18 +5,24 @@
 'use strict';
 
 var React = require('react');
+var inherits = require('inherits');
 
-var FluxibleComponent = React.createClass({
-    displayName: 'FluxibleComponent',
-    propTypes: {
-        context: React.PropTypes.object.isRequired
-    },
+function FluxibleComponent(props, context) {
+    React.Component.apply(this, arguments);
+}
 
-    childContextTypes: {
-        executeAction: React.PropTypes.func.isRequired,
-        getStore: React.PropTypes.func.isRequired
-    },
+inherits(FluxibleComponent, React.Component);
 
+FluxibleComponent.displayName = 'FluxibleComponent';
+FluxibleComponent.propTypes = {
+    context: React.PropTypes.object.isRequired
+};
+FluxibleComponent.childContextTypes = {
+    executeAction: React.PropTypes.func.isRequired,
+    getStore: React.PropTypes.func.isRequired
+};
+
+Object.assign(FluxibleComponent.prototype, {
     /**
      * Provides the current context as a child context
      * @method getChildContext

--- a/packages/fluxible-addons-react/package.json
+++ b/packages/fluxible-addons-react/package.json
@@ -13,7 +13,8 @@
     "lint": "../../node_modules/.bin/eslint *.js tests/"
   },
   "dependencies": {
-    "hoist-non-react-statics": "^1.0.0"
+    "hoist-non-react-statics": "^1.0.0",
+    "inherits": "^2.0.1"
   },
   "peerDependencies": {
     "fluxible": ">=1.0.0",

--- a/packages/fluxible-addons-react/provideContext.js
+++ b/packages/fluxible-addons-react/provideContext.js
@@ -6,6 +6,7 @@
 
 var React = require('react');
 var hoistNonReactStatics = require('hoist-non-react-statics');
+var inherits = require('inherits');
 
 function createComponent(Component, customContextTypes) {
     var componentName = Component.displayName || Component.name;
@@ -14,15 +15,19 @@ function createComponent(Component, customContextTypes) {
         getStore: React.PropTypes.func.isRequired
     }, customContextTypes || {});
 
-    var ContextProvider = React.createClass({
-        displayName: componentName + 'ContextProvider',
+    function ContextProvider(props, context) {
+        React.Component.apply(this, arguments);
+    }
 
-        propTypes: {
-            context: React.PropTypes.object.isRequired
-        },
+    inherits(ContextProvider, React.Component);
 
-        childContextTypes: childContextTypes,
+    ContextProvider.displayName = componentName + 'ContextProvider';
+    ContextProvider.propTypes = {
+        context: React.PropTypes.object.isRequired
+    };
+    ContextProvider.childContextTypes = childContextTypes;
 
+    Object.assign(ContextProvider.prototype, {
         getChildContext: function () {
             var childContext = {
                 executeAction: this.props.context.executeAction,

--- a/packages/fluxible-router/lib/createNavLinkComponent.js
+++ b/packages/fluxible-router/lib/createNavLinkComponent.js
@@ -24,6 +24,7 @@ function isModifiedEvent (e) {
  */
 module.exports = function createNavLinkComponent (overwriteSpec) {
     var NavLink = React.createClass(Object.assign({}, {
+        autobind: false,
         displayName: 'NavLink',
         contextTypes: {
             executeAction: React.PropTypes.func.isRequired,
@@ -43,6 +44,7 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
         },
         componentDidMount: function () {
             var routeStore = this.context.getStore(RouteStore);
+            this._onRouteStoreChange = this.constructor.prototype._onRouteStoreChange.bind(this);
             routeStore.addChangeListener(this._onRouteStoreChange);
         },
         componentWillUnmount: function () {
@@ -174,7 +176,7 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             return React.createElement(
                 'a',
                 Object.assign({}, {
-                    onClick: this.clickHandler
+                    onClick: this.clickHandler.bind(this)
                 }, this.props, {
                     href: this.state.href,
                     className: this.state.className,

--- a/packages/fluxible-router/lib/handleHistory.js
+++ b/packages/fluxible-router/lib/handleHistory.js
@@ -15,6 +15,7 @@ var TYPE_REPLACESTATE = 'replacestate';
 var TYPE_POPSTATE = 'popstate';
 var TYPE_DEFAULT = 'default'; // default value if navigation type is missing, for programmatic navigation
 var hoistNonReactStatics = require('hoist-non-react-statics');
+var inherits = require('inherits');
 
 var defaultOptions = {
     checkRouteOnPageLoad: false,
@@ -43,29 +44,38 @@ var historyCreated = false;
 function createComponent(Component, opts) {
     var options = Object.assign({}, defaultOptions, opts);
 
-    var HistoryHandler = React.createClass({
-        displayName: 'HistoryHandler',
-        contextTypes: {
-            executeAction: React.PropTypes.func.isRequired
-        },
+    function HistoryHandler(props, context) {
+        React.Component.apply(this, arguments);
+    }
 
-        propTypes: {
-            currentRoute: React.PropTypes.object,
-            currentNavigate: React.PropTypes.object
-        },
+    inherits(HistoryHandler, React.Component);
 
-        getDefaultProps: function () {
-            return {
-                currentRoute: null,
-                currentNavigate: null
-            };
-        },
+    HistoryHandler.displayName = 'HistoryHandler';
+    HistoryHandler.contextTypes = {
+        executeAction: React.PropTypes.func.isRequired
+    };
+    HistoryHandler.propTypes = {
+        currentRoute: React.PropTypes.object,
+        currentNavigate: React.PropTypes.object
+    };
+    HistoryHandler.defaultProps = {
+        currentRoute: null,
+        currentNavigate: null
+    };
+
+    Object.assign(HistoryHandler.prototype, {
 
         componentDidMount: function () {
             if (historyCreated) {
                 throw new Error('Only one history handler should be on the ' +
                 'page at a time.');
             }
+
+            // Bind the event listeners
+            this._onHistoryChange = this.constructor.prototype._onHistoryChange.bind(this);
+            this._onScroll = this.constructor.prototype._onScroll.bind(this);
+            this._saveScrollPosition = this.constructor.prototype._saveScrollPosition.bind(this);
+
             this._history = options.historyCreator();
             this._scrollTimer = null;
 

--- a/packages/fluxible-router/lib/handleRoute.js
+++ b/packages/fluxible-router/lib/handleRoute.js
@@ -7,20 +7,27 @@
 var React = require('react');
 var connectToStores = require('fluxible-addons-react/connectToStores');
 var hoistNonReactStatics = require('hoist-non-react-statics');
+var inherits = require('inherits');
 
 function createComponent(Component) {
-    var RouteHandler = React.createClass({
-        displayName: 'RouteHandler',
-        contextTypes: {
-            getStore: React.PropTypes.func.isRequired
-        },
-        propTypes: {
-            currentRoute: React.PropTypes.object,
-            currentNavigate: React.PropTypes.object,
-            currentNavigateError: React.PropTypes.object,
-            isNavigateComplete: React.PropTypes.bool
-        },
+    function RouteHandler(props, context) {
+        React.Component.apply(this, arguments);
+    }
 
+    inherits(RouteHandler, React.Component);
+
+    RouteHandler.displayName = 'RouteHandler';
+    RouteHandler.contextTypes = {
+        getStore: React.PropTypes.func.isRequired
+    };
+    RouteHandler.propTypes = {
+        currentRoute: React.PropTypes.object,
+        currentNavigate: React.PropTypes.object,
+        currentNavigateError: React.PropTypes.object,
+        isNavigateComplete: React.PropTypes.bool
+    };
+
+    Object.assign(RouteHandler.prototype, {
         render: function () {
             var routeStore = this.context.getStore('RouteStore');
 


### PR DESCRIPTION
This should improve performance during instantiation of the components significantly.