### PR TITLE
Consistently use the public API for `Store`

### DIFF
--- a/packages/fluxible-addons-react/FluxibleMixin.js
+++ b/packages/fluxible-addons-react/FluxibleMixin.js
@@ -185,7 +185,7 @@ var FluxibleMixin = {
             throw new Error('storeListener mixin called listen when component wasn\'t mounted.');
         }
 
-        listener.store.addChangeListener(listener.handler);
+        listener.store.on('change', listener.handler);
         this._fluxible_listeners.push(listener);
     },
 
@@ -196,7 +196,7 @@ var FluxibleMixin = {
     componentWillUnmount: function componentWillUnmount() {
         if (Array.isArray(this._fluxible_listeners)) {
             this._fluxible_listeners.forEach(function (listener) {
-                listener.store.removeChangeListener(listener.handler);
+                listener.store.removeListener('change', listener.handler);
             });
         }
         this._fluxible_listeners = [];

--- a/packages/fluxible-addons-react/connectToStores.js
+++ b/packages/fluxible-addons-react/connectToStores.js
@@ -31,13 +31,13 @@ function createComponent(Component, stores, getStateFromStores, customContextTyp
             this._isMounted = true;
             this._onStoreChange = this.constructor.prototype._onStoreChange.bind(this);
             stores.forEach(function storesEach(Store) {
-                this.context.getStore(Store).addChangeListener(this._onStoreChange);
+                this.context.getStore(Store).on('change', this._onStoreChange);
             }, this);
         },
         componentWillUnmount: function componentWillUnmount() {
             this._isMounted = false;
             stores.forEach(function storesEach(Store) {
-                this.context.getStore(Store).removeChangeListener(this._onStoreChange);
+                this.context.getStore(Store).removeListener('change', this._onStoreChange);
             }, this);
         },
         componentWillReceiveProps: function componentWillReceiveProps(nextProps){


### PR DESCRIPTION
As discussed in #355, `addChangeListener` / `remvoeChangeListener` are
convenience methods added by `BaseStore` and `createStore`, but not
necessarily defined on any instance of `Store`. To ensure
`connectToStores` and `FluxibleMixin` work with every store instance, we
use the `EventEmitter` API to listen for `change` events instead.

Fixes #356.