### PR TITLE
Fixing initial copyright year

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement (BSD License)
 ========================================
 
-Copyright (c) 2015, Yahoo Inc. All rights reserved.
+Copyright (c) 2014-2016, Yahoo Inc. All rights reserved.
 ----------------------------------------------------
 
 Redistribution and use of this software in source and binary forms, with or


### PR DESCRIPTION
According to http://www.copyright.gov/circs/circ01.pdf , document should list its first year of publication in its copyright

Initial copyright year was 2014 (As per commit 9c316315615b110560e3a9276cc65e )