### PR TITLE
[resolves #352] Bump babel-eslint to latest

### DIFF
--- a/packages/generator-fluxible/app/templates/package.json
+++ b/packages/generator-fluxible/app/templates/package.json
@@ -29,7 +29,7 @@
     "serve-favicon": "^2.1.6"
   },
   "devDependencies": {
-    "babel-eslint": "^3.0.1",
+    "babel-eslint": "^4.1.6",
     "babel-loader": "^5.1.3",
     "bundle-loader": "^0.5.0",
     "eslint": "^0.24.0",


### PR DESCRIPTION
On babel-eslint@3.1.30, the following error occurs:

```shell
$ npm run lint

> test@0.0.0 lint /Volumes/Projects/test
> eslint ./*.js ./**/*.js


/Volumes/Projects/test/node_modules/eslint/node_modules/escope/node_modules/esrecurse/esrecurse.js:0
(function (exports, require, module, __filename, __dirname) { /*
^
RangeError: Maximum call stack size exceeded
```