### PR TITLE
Allow navParams to be overwritten by overwriteSpec

### DIFF
--- a/packages/fluxible-router/lib/createNavLinkComponent.js
+++ b/packages/fluxible-router/lib/createNavLinkComponent.js
@@ -87,19 +87,24 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             var href = props.href;
             var routeName = props.routeName;
             var routeStore = this.context.getStore(RouteStore);
+            var navParams = this.getNavParams(props);
             if (!href && routeName) {
-                href = routeStore.makePath(routeName, props.navParams);
+                href = routeStore.makePath(routeName, navParams);
             }
             if (!href) {
                 throw new Error('NavLink created without href or unresolvable ' +
                     'routeName \'' + routeName + '\' with params ' +
-                    JSON.stringify(props.navParams));
+                    JSON.stringify(navParams));
             }
             return href;
         },
+        getNavParams: function (props) {
+            return props.navParams;
+        },
         dispatchNavAction: function (e) {
+            var navParams = this.getNavParams(this.props);
             var navType = this.props.replaceState ? 'replacestate' : 'click';
-            debug('dispatchNavAction: action=NAVIGATE', this.props.href, this.props.followLink, this.props.navParams);
+            debug('dispatchNavAction: action=NAVIGATE', this.props.href, this.props.followLink, navParams);
 
             if (this.props.followLink) {
                 return;
@@ -150,7 +155,7 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
                     type: navType,
                     url: href,
                     preserveScrollPosition: this.props.preserveScrollPosition,
-                    params: this.props.navParams
+                    params: navParams
                 });
             }
         },

--- a/packages/fluxible-router/tests/unit/lib/NavLink-test.js
+++ b/packages/fluxible-router/tests/unit/lib/NavLink-test.js
@@ -6,6 +6,7 @@
 var React;
 var ReactDOM;
 var NavLink;
+var createNavLinkComponent;
 var ReactTestUtils;
 var jsdom = require('jsdom');
 var expect = require('chai').expect;
@@ -46,6 +47,7 @@ describe('NavLink', function () {
         });
         MockAppComponent = require('../../mocks/MockAppComponent');
         NavLink = require('../../../lib/NavLink');
+        createNavLinkComponent = require('../../../lib/createNavLinkComponent');
         testResult = {};
     });
 
@@ -157,6 +159,33 @@ describe('NavLink', function () {
                 expect(mockContext.executeActionCalls[0].payload.url).to.equal('/foo');
                 expect(mockContext.executeActionCalls[0].payload.preserveScrollPosition).to.equal(true);
                 expect(mockContext.executeActionCalls[0].payload.params).to.eql({a: 1, b: true});
+                done();
+            }, 10);
+        });
+        it ('should getNavParams from overwriteSpec if so configured', function (done) {
+            var navParams = {a: 1, b: true};
+            var params = {
+                href:'/foo',
+                preserveScrollPosition:true,
+                navParams: navParams
+            };
+            var navLink = React.createElement(createNavLinkComponent({
+                getNavParams: function () {
+                    return {a: 2, b: false};
+                }
+            }), params);
+            var link = ReactTestUtils.renderIntoDocument(
+                <MockAppComponent context={mockContext}>
+                    {navLink}
+                </MockAppComponent>
+            );
+            ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link), {button: 0});
+            window.setTimeout(function () {
+                expect(mockContext.executeActionCalls[0].action).to.equal(navigateAction);
+                expect(mockContext.executeActionCalls[0].payload.type).to.equal('click');
+                expect(mockContext.executeActionCalls[0].payload.url).to.equal('/foo');
+                expect(mockContext.executeActionCalls[0].payload.preserveScrollPosition).to.equal(true);
+                expect(mockContext.executeActionCalls[0].payload.params).to.eql({a: 2, b: false});
                 done();
             }, 10);
         });


### PR DESCRIPTION
@lingyan 

This exposes getNavParams to the overwriteSpec so that it can be overwritten should a component need to set custom navParams during one of the other event hooks.