### PR TITLE
Add getStore to storeContext

### DIFF
--- a/packages/fluxible/lib/FluxibleContext.js
+++ b/packages/fluxible/lib/FluxibleContext.js
@@ -307,7 +307,11 @@ FluxContext.prototype.getStoreContext = function getStoreContext() {
         return this._storeContext;
     }
     var self = this;
-    var storeContext = {};
+    var storeContext = {
+        getStore: function(store) {
+            return self._dispatcher.getStore(store);
+        }
+    };
 
     self._plugins.forEach(function pluginsEach(plugin) {
         var storeContextPlugin = plugin.plugStoreContext;


### PR DESCRIPTION
Plugins working with plugStoreContext have no access to getStore function.
I added it.

PS. ugly and tested this time...