### PR TITLE
Fluxible-Router: Always Set _currentNavigate Regardless If the Routes Match

### DIFF
--- a/packages/fluxible-router/lib/RouteStore.js
+++ b/packages/fluxible-router/lib/RouteStore.js
@@ -35,9 +35,9 @@ var RouteStore = createStore({
 
         if (!this._areEqual(matchedRoute, this._currentRoute)) {
             this._currentRoute = matchedRoute;
-            this._currentNavigate = navigate;
         }
 
+        this._currentNavigate = navigate;
         this._currentNavigateError = null;
         this._isNavigateComplete = false;
         this._currentUrl = navigate.url;


### PR DESCRIPTION
@mridgway @lingyan 

This PR does the following:
  - Always sets the `_currentNavigate` property in the `_handleNavigateStart()` method, regardless if the current route matches the existing route.

**Use Case:**

  1.  Load a site's homepage and throw an error (the user is suspended)
  2.  The user clicks on the homepage navigation button (the navigation bar is still available) to "refresh" the homepage.
  3.  The `RouteStore` is checked to make sure it has completed loading before the user can interact with the page again, but the `RouteStore` never "completes" due to the new route (homepage) matching the old route (homepage)

**Tests:** Existing tests pass