### PR TITLE
not check matched route before updating currentRoute

### DIFF
--- a/packages/fluxible-router/lib/RouteStore.js
+++ b/packages/fluxible-router/lib/RouteStore.js
@@ -33,10 +33,7 @@ var RouteStore = createStore({
             method: navigate.method
         });
 
-        if (!this._areEqual(matchedRoute, this._currentRoute)) {
-            this._currentRoute = matchedRoute;
-        }
-
+        this._currentRoute = matchedRoute;
         this._currentNavigate = navigate;
         this._currentNavigateError = null;
         this._isNavigateComplete = false;

--- a/packages/fluxible-router/tests/unit/lib/RouteStore-test.js
+++ b/packages/fluxible-router/tests/unit/lib/RouteStore-test.js
@@ -8,6 +8,10 @@ var StaticRouteStore = RouteStore.withStaticRoutes({
     foo: {
         path: '/foo',
         method: 'get'
+    },
+    bar : {
+        path: '/bar',
+        method: 'get'
     }
 });
 
@@ -104,6 +108,22 @@ describe('RouteStore', function () {
                 message: 'Url /unknown does not match any routes'
             });
             expect(routeStore.isNavigateComplete()).to.equal(true);
+        });
+        it('should update transactionId', function () {
+            routeStore._handleNavigateStart({
+                transactionId: 'second',
+                url: '/bar',
+                method: 'get'
+            });
+            expect(routeStore.getCurrentRoute().navigate.transactionId).to.equal('second');
+        });
+        it('should update transactionId with same url navigation', function () {
+            routeStore._handleNavigateStart({
+                transactionId: 'second',
+                url: '/foo',
+                method: 'get'
+            });
+            expect(routeStore.getCurrentRoute().navigate.transactionId).to.equal('second');
         });
     });
 


### PR DESCRIPTION
@mridgway @lingyan @redonkulus 

similar as #367 

the PR fix an issue that we have `navigate` object, which includes `transection id`, it's not updated when we navigate to the same url. 

@mridgway instead of having a `else` condition to just update `navigate` id, the proposal of this PR is just updating currentRoute anyway. otherwise when we navigate to the same url, the flow still finishes (i.e., we have NAVIGATE_START, NAVIGATE_SUCCESS ...everything), but `currentRoute` is not updated , might cause some issue if url is keeping the same but with different `params/query`. 

