### PR TITLE
Follow NavLinks that do not match a registered route

### DIFF
--- a/examples/fluxible-router/components/Nav.js
+++ b/examples/fluxible-router/components/Nav.js
@@ -10,6 +10,9 @@ function Nav () {
         <ul className="pure-menu pure-menu-open pure-menu-horizontal">
             <li><NavLink routeName="home" activeStyle={{backgroundColor: '#ccc'}}>Home</NavLink></li>
             <li><NavLink routeName="about" activeStyle={{backgroundColor: '#ccc'}}>About</NavLink></li>
+            <li><NavLink href="/page/Relative" activeStyle={{backgroundColor: '#ccc'}}>Relative Href</NavLink></li>
+            <li><NavLink autoMatch={true} href="internal" activeStyle={{backgroundColor: '#ccc'}}>AutoMatch Href Internal</NavLink></li>
+            <li><NavLink autoMatch={true} href="//www.yahoo.com" activeStyle={{backgroundColor: '#ccc'}}>AutoMatch Href External</NavLink></li>
         </ul>
     );
 }

--- a/examples/fluxible-router/configs/routes.js
+++ b/examples/fluxible-router/configs/routes.js
@@ -23,6 +23,17 @@ export default {
             done();
         }
     },
+    internal: {
+        path: '/internalPage',
+        method: 'get',
+        handler: require('../components/Page'),
+        label: 'Internal',
+        action: (context, payload, done) => {
+            context.dispatch('LOAD_PAGE', { id: 'Internal Page' });
+            context.dispatch('UPDATE_PAGE_TITLE', { pageTitle: 'Internal Page | flux-examples | routing' });
+            done();
+        }
+    },
     dynamicpage: {
         path: '/page/:id',
         method: 'get',

--- a/packages/fluxible-router/lib/createNavLinkComponent.js
+++ b/packages/fluxible-router/lib/createNavLinkComponent.js
@@ -37,7 +37,8 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             navParams: React.PropTypes.object,
             followLink: React.PropTypes.bool,
             preserveScrollPosition: React.PropTypes.bool,
-            replaceState: React.PropTypes.bool
+            replaceState: React.PropTypes.bool,
+            autoMatch: React.PropTypes.bool
         },
         getInitialState: function () {
             return this._getState(this.props);
@@ -88,6 +89,9 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             var routeName = props.routeName;
             var routeStore = this.context.getStore(RouteStore);
             var navParams = this.getNavParams(props);
+            if(props.autoMatch && href) {
+                href = routeStore.makePath(href, navParams) || href;
+            }
             if (!href && routeName) {
                 href = routeStore.makePath(routeName, navParams);
             }
@@ -108,6 +112,7 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             var navParams = this.getNavParams(this.props);
             var navType = this.props.replaceState ? 'replacestate' : 'click';
             var shouldFollowLink = this.shouldFollowLink(this.props);
+            var routeStore = this.context.getStore(RouteStore);
             debug('dispatchNavAction: action=NAVIGATE', this.props.href, shouldFollowLink, navParams);
             
             if (this.props.stopPropagation) {
@@ -132,7 +137,7 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
                 return;
             }
 
-            if (href[0] !== '/') {
+            if (href[0] !== '/' || (this.props.autoMatch && !routeStore.getRoute(href))) {
                 // this is not a relative url. check for external urls.
                 var location = window.location;
                 var origin = location.origin || (location.protocol + '//' + location.host);


### PR DESCRIPTION
Attempt to solve this issue #337 
New logic on href field of NavLink:
- href is treated as routeName. if such routeName doesn't exist in route, use href directly.