### PR TITLE
Upgrade generator-fluxible to use latest fluxible-router

### DIFF
--- a/packages/generator-fluxible/app/templates/components/Application.js
+++ b/packages/generator-fluxible/app/templates/components/Application.js
@@ -9,7 +9,7 @@ import pages from '../configs/routes';
 
 class Application extends React.Component {
     render() {
-        var Handler = this.props.currentRoute.get('handler');
+        var Handler = this.props.currentRoute.handler;
 
         return (
             <div>

--- a/packages/generator-fluxible/app/templates/components/Nav.js
+++ b/packages/generator-fluxible/app/templates/components/Nav.js
@@ -10,7 +10,7 @@ class Nav extends React.Component {
             var className = '';
             var link = links[name];
 
-            if (selected && selected.get('name') === name) {
+            if (selected && selected.name === name) {
                 className = 'pure-menu-selected';
             }
 

--- a/packages/generator-fluxible/app/templates/package.json
+++ b/packages/generator-fluxible/app/templates/package.json
@@ -22,7 +22,7 @@
     "fluxible": "^1.0.0",
     "fluxible-addons-react": "^0.2.0",
     "fluxible-plugin-fetchr": "^0.3.0",
-    "fluxible-router": "^0.3.0",
+    "fluxible-router": "^0.4.0",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
     "serialize-javascript": "^1.0.0",

--- a/packages/generator-fluxible/app/templates/stores/ApplicationStore.js
+++ b/packages/generator-fluxible/app/templates/stores/ApplicationStore.js
@@ -8,8 +8,8 @@ class ApplicationStore extends BaseStore {
     }
     handlePageTitle(currentRoute) {
         this.dispatcher.waitFor(RouteStore, () => {
-            if (currentRoute && currentRoute.get('title')) {
-                this.pageTitle = currentRoute.get('title');
+            if (currentRoute && currentRoute.title) {
+                this.pageTitle = currentRoute.title;
                 this.emitChange();
             }
         });


### PR DESCRIPTION
This pull request upgrades the `generator-fluxible` package to use the latest version of `fluxible-router`, version `0.4.7`. Route object  `.get` has been replaced with direct field access.