### PR TITLE
Unification of executeAction between ActionContext and MockActionContext

### DIFF
--- a/packages/fluxible/tests/unit/utils/createMockActionContext.js
+++ b/packages/fluxible/tests/unit/utils/createMockActionContext.js
@@ -84,12 +84,16 @@ describe('createMockActionContext', function () {
                 });
             });
 
-            it('should execute the action and infer to NOT return a Promise', function () {
+            it('should execute the action and return a Promise', function (done) {
                 var returnValue = 'mock';
-                var result = context.executeAction(mockAction, mockPayload, cbResult(function () {
-                    return returnValue;
-                }));
-                expect(result).to.equal(returnValue);
+                var result = context.executeAction(function (context, payload, fn) {
+                    fn(null, returnValue);
+                }, mockPayload);
+                expect(result.then).to.be.a('function');
+                result.then(function (r) {
+                    expect(r).to.equal(returnValue);
+                    done();
+                })['catch'](done);
             });
         });
 

--- a/packages/fluxible/utils/MockActionContext.js
+++ b/packages/fluxible/utils/MockActionContext.js
@@ -30,7 +30,7 @@ MockActionContext.prototype.executeAction = function (action, payload, callback)
         action: action,
         payload: payload
     });
-    return callAction(action, this, payload, callback);
+    return callAction(this, action, payload, callback);
 };
 
 module.exports = MockActionContext;


### PR DESCRIPTION
**This is a potentially breaking change** that I want to be careful about. 

### Problem

Given the example:

```js
var fooAction = function () { 
    return 'foo'; 
};
```

* `MockActionContext.executeAction` currently returns the return value of the action: `'foo' == mockActionContext.executeAction(fooAction)`. 
* `FluxibleContext.executeAction` returns a `Promise` that would be resolved with the value 'foo'.

The problem with this is that if there are nested `executeAction` calls, then the parent action will not receive a `Promise` as it would expect:

```js
var parentAction = function (context) {
    return context.executeAction(fooAction).then(function (result) {
        console.log(result);
    });;
}
```

This causes significant problems in testing a code base that is mixed with actions that use Promises and callbacks, which is supported by FluxibleContext, but not MockActionContext.

### Solution

The solution is to ensure that they are using the same implementation. In this PR I have made both contexts use the same implementation.

### Breaking Change or Bug?

I could easily mark this as a bug, since it presents an inconsistency which makes it impossible to test certain cases. The issue however, is that there will be many tests out there that may be affected by this change:

 1. Tests that relied on the return value of `executeAction` to match the action's return value.
    * This is resolved by calling the action directly instead of through `executeAction`.
 2. The ordering of parallel actions could change due to the `setImmediate`. Any tests that rely on the order of parallel actions (which you could argue is unsafe) could be broken.
    * This is resolved by making tests not reliant on order of parallel actions.

We found a few tests (5 out of 301 tests) in one internal package that were affected due to the second item. We never relied on the first, but others in the community may be.

### Options

1. Classify as a bug and release as a patch fix. Users may be affected by broken tests.
2. Classify as a breaking change and release as a major version bump (2.x). No one is affected immediately, but a migration would be need to upgrade to 2.x.
3. Classify as a breaking change and release a separate `MockActionContext` API (what would we even name it?) and release as minor version or a separate package. Current MockActionContext would be deprecated in 2.x. This minimizes the breakage but would still eventually require a migration when 2.x is released.

### Request for Input

I would love to get the community's input on this. I'm also curious how many people are affected by these issues. 

**Please try installing `fluxible@test` in your project and run your test suite. Please report any breakages that you see.**

Assuming the impact is minimal, we will go ahead with releasing this as a bug fix that gets released as `1.0.4`.