### PR TITLE
Fix overflow scroll bar issue

### DIFF
--- a/site/components/Search.jsx
+++ b/site/components/Search.jsx
@@ -88,7 +88,7 @@ class Search extends React.Component {
         let classes = cx({
             'D(ib) Mstart(3px) Ov(h) Va(m) Pos(a) End(20px)': true,
             'W(0)': this.state.visible === false,
-            'W(200px) Ov(h)': this.state.visible
+            'W(200px)': this.state.visible
         });
         return (
             <div className="D(ib)">

--- a/site/components/Search.jsx
+++ b/site/components/Search.jsx
@@ -88,7 +88,7 @@ class Search extends React.Component {
         let classes = cx({
             'D(ib) Mstart(3px) Ov(h) Va(m) Pos(a) End(20px)': true,
             'W(0)': this.state.visible === false,
-            'W(200px) Ov(a)': this.state.visible
+            'W(200px) Ov(h)': this.state.visible
         });
         return (
             <div className="D(ib)">


### PR DESCRIPTION
Current search bar:
[![https://gyazo.com/c28ff3f3527c7ae0fc4d8ed1bc5540f1](https://i.gyazo.com/c28ff3f3527c7ae0fc4d8ed1bc5540f1.png)](https://gyazo.com/c28ff3f3527c7ae0fc4d8ed1bc5540f1)

I think `overflow:hidden` would be enough.