### PR TITLE
Fix param tag description in plugin example

### DIFF
--- a/packages/fluxible/docs/api/Plugins.md
+++ b/packages/fluxible/docs/api/Plugins.md
@@ -30,7 +30,7 @@ app.plug({
             /**
              * Method called to allow modification of the component context
              * @method plugComponentContext
-             * @param {Object} componentContext Options passed into createContext
+             * @param {Object} componentContext ComponentContext instance
              * @param {Object} context FluxibleContext instance
              * @param {Object} app Fluxible instance
              */


### PR DESCRIPTION
Just a quick fix to the plugin example. The first argument for `plugComponentContext` is a `ComponentContext` and not the options passed to `Fluxible.createContext(options)`.