### PR TITLE
Extract shouldFollowLink() method

### DIFF
--- a/packages/fluxible-router/lib/createNavLinkComponent.js
+++ b/packages/fluxible-router/lib/createNavLinkComponent.js
@@ -101,12 +101,16 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
         getNavParams: function (props) {
             return props.navParams;
         },
+        shouldFollowLink: function(props) {
+            return props.followLink;
+        },
         dispatchNavAction: function (e) {
             var navParams = this.getNavParams(this.props);
             var navType = this.props.replaceState ? 'replacestate' : 'click';
-            debug('dispatchNavAction: action=NAVIGATE', this.props.href, this.props.followLink, navParams);
+            var shouldFollowLink = this.shouldFollowLink(this.props);
+            debug('dispatchNavAction: action=NAVIGATE', this.props.href, shouldFollowLink, navParams);
 
-            if (this.props.followLink) {
+            if (shouldFollowLink) {
                 return;
             }
 


### PR DESCRIPTION
@lingyan @kaesonho 

Extract `shouldFollowLink()` method, that we can override with customized behavior on followLink.

Related PR: https://github.com/yahoo/react-i13n/pull/80