### PR TITLE
stopPropagation in all cases

### DIFF
--- a/packages/fluxible-router/lib/createNavLinkComponent.js
+++ b/packages/fluxible-router/lib/createNavLinkComponent.js
@@ -109,6 +109,10 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             var navType = this.props.replaceState ? 'replacestate' : 'click';
             var shouldFollowLink = this.shouldFollowLink(this.props);
             debug('dispatchNavAction: action=NAVIGATE', this.props.href, shouldFollowLink, navParams);
+            
+            if (this.props.stopPropagation) {
+                e.stopPropagation();
+            }
 
             if (shouldFollowLink) {
                 return;
@@ -143,9 +147,6 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             }
 
             e.preventDefault();
-            if (this.props.stopPropagation) {
-                e.stopPropagation();
-            }
 
             var context = this.props.context || this.context;
             var onBeforeUnloadText = typeof window.onbeforeunload === 'function' ? window.onbeforeunload() : '';


### PR DESCRIPTION
Move stopPropagation to top of the handler, to prevent propagation in case of modified event or right click event.

Steps to repro:

1. Place NavLink inside an element, which have onClick handler.
2. Set `stopPropagation` attribute of NavLink to `true`.
3. Press CMD+LM or RM.

Expected: propagation stopped, outer element onClick handler never called.

Actual: propagation did not stopped, onClick on outer element fired.