### PR TITLE
allow ignore popstate event on page load, this is mainly a fix for sa…

### DIFF
--- a/packages/fluxible-router/docs/api/handleHistory.md
+++ b/packages/fluxible-router/docs/api/handleHistory.md
@@ -9,6 +9,7 @@ The `handleHistory` higher-order component handles the browser history state man
 | `checkRouteOnPageLoad` | `false` | Performs navigate on first page load |
 | `enableScroll` | `true` | Saves scroll position in history state |
 | `historyCreator` | [`History`](../../lib/History.js) | A factory for creating the history implementation |
+| `ignorePopstateOnPageLoad` | `false` | A boolean value or a function that returns a boolean value. [Browsers tend to handle the popstate event differently on page load. Chrome (prior to v34) and Safari always emit a popstate event on page load, but Firefox doesn't.](https://developer.mozilla.org/en-US/docs/Web/Events/popstate) This flag is for ignoring popstate event triggered on page load if that causes issue for your application, as reported in [issue #349](https://github.com/yahoo/fluxible/issues/349). |
 
 ## Example Usage
 

--- a/packages/fluxible-router/tests/unit/lib/handleHistory-test.js
+++ b/packages/fluxible-router/tests/unit/lib/handleHistory-test.js
@@ -264,6 +264,106 @@ describe('handleHistory', function () {
                         done();
                     }, 10);
                 });
+                describe('handle popstate event on page load', function () {
+                    it('execute navigation action when ignorePopstateOnPageLoad is false', function (done) {
+                        var routeStore = mockContext.getStore('RouteStore');
+                        routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
+                        var MockAppComponent = mockCreator({
+                            checkRouteOnPageLoad: false,
+                            historyCreator: function () {
+                                return historyMock('/browserUrl', {a: 1});
+                            },
+                            ignorePopstateOnPageLoad: false
+                        });
+
+                        // simulate page load popstate
+                        window.dispatchEvent(Object.assign(new Event('popstate'), {state: null}));
+
+                        ReactTestUtils.renderIntoDocument(
+                            <MockAppComponent context={mockContext} />
+                        );
+
+                        setTimeout(function() {
+                            expect(mockContext.executeActionCalls.length).to.equal(1);
+                            expect(mockContext.executeActionCalls[0].action).to.be.a('function');
+                            expect(mockContext.executeActionCalls[0].payload.type).to.equal('popstate');
+                            expect(mockContext.executeActionCalls[0].payload.url).to.equal('/browserUrl');
+                            done();
+                        }, 150);
+                    });
+                    it('skip navigation action when ignorePopstateOnPageLoad is true', function (done) {
+                        var routeStore = mockContext.getStore('RouteStore');
+                        routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
+                        var MockAppComponent = mockCreator({
+                            checkRouteOnPageLoad: false,
+                            historyCreator: function () {
+                                return historyMock('/browserUrl', {a: 1});
+                            },
+                            ignorePopstateOnPageLoad: true
+                        });
+
+                        // simulate page load popstate
+                        window.dispatchEvent(Object.assign(new Event('popstate'), {state: null}));
+
+                        ReactTestUtils.renderIntoDocument(
+                            <MockAppComponent context={mockContext} />
+                        );
+
+                        setTimeout(function() {
+                            expect(mockContext.executeActionCalls.length).to.equal(0);
+                            done();
+                        }, 150);
+                    });
+                    it('ignorePopstateOnPageLoad can be a function that returns false', function (done) {
+                        var routeStore = mockContext.getStore('RouteStore');
+                        routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
+                        var MockAppComponent = mockCreator({
+                            checkRouteOnPageLoad: false,
+                            historyCreator: function () {
+                                return historyMock('/browserUrl', {a: 1});
+                            },
+                            ignorePopstateOnPageLoad: function () { return false; }
+                        });
+
+                        // simulate page load popstate
+                        window.dispatchEvent(Object.assign(new Event('popstate'), {state: null}));
+
+                        ReactTestUtils.renderIntoDocument(
+                            <MockAppComponent context={mockContext} />
+                        );
+
+                        setTimeout(function() {
+                            expect(mockContext.executeActionCalls.length).to.equal(1);
+                            expect(mockContext.executeActionCalls[0].action).to.be.a('function');
+                            expect(mockContext.executeActionCalls[0].payload.type).to.equal('popstate');
+                            expect(mockContext.executeActionCalls[0].payload.url).to.equal('/browserUrl');
+                            done();
+                        }, 150);
+                    });
+                    it('ignorePopstateOnPageLoad can be a function that returns true', function (done) {
+                        var routeStore = mockContext.getStore('RouteStore');
+                        routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
+                        var MockAppComponent = mockCreator({
+                            checkRouteOnPageLoad: false,
+                            historyCreator: function () {
+                                return historyMock('/browserUrl', {a: 1});
+                            },
+                            ignorePopstateOnPageLoad: function () { return true; }
+                        });
+
+                        // simulate page load popstate
+                        window.dispatchEvent(Object.assign(new Event('popstate'), {state: null}));
+
+                        ReactTestUtils.renderIntoDocument(
+                            <MockAppComponent context={mockContext} />
+                        );
+
+                        setTimeout(function() {
+                            expect(mockContext.executeActionCalls.length).to.equal(0);
+                            done();
+                        }, 150);
+                    });
+                });
                 describe('window.onbeforeunload', function () {
                     beforeEach(function () {
                         global.window.confirm = function () { return false; };


### PR DESCRIPTION
…fari browser, see discussions in issue #349 and PR #351 for more details

@mridgway @redonkulus @kaesonho 
cc: @skippykawakami 

This PR does not change existing behavior, by introducing the fix behind a feature flag `ignorePopstateOnPageLoad`, with default value `false`.  Most of the apps will not need to enable this.  It is only needed for a special case where the url in currentRoute (in dehydrated RouteStore) is different from what is in the browser, typical due to an intermediate layer like ATS altering url (adding query parameter whatnot) before sending request to origin server.

The mechanism for identifying pageload popstate event:
* In Safari browser, when page loads, browser will trigger a popstate event with `null` state (in `event.state`)
* But we can't just check for `event.state === null` of popstate events to say it is triggered by page load, because if you load a new page in a browser, navigate to a new page, and on back button, a popstate event will be triggered, this event's `state` property will be `null`.
* To get around that, we manually replace the history state on page load (in componentDidMount() to be exact).  This way, all pages loaded with fluxible-router or client-navigated with fluxible-router will guarantee to have a non-null history.state object.  So all regular popstate events will guarantee to have a non-null `event.state`.

With that, we can use the following logic to tell whether the popstate event is triggered on page load:
```
                var stateFromHistory = this._history.getState();
                var isPageloadPopstate = (e.state === null) && !!stateFromHistory;
                debug('history listener detecting pageload popstate', e.state, stateFromHistory);
                if (isPageloadPopstate) {
                    debug('history listener skipped pageload popstate');
                    return;
                }
```

Some other alternatives for this issue is to delay `window.addEventListener('popstate', ...)` to after onload event.  Did not want to go that route, since that could introduce a delay comparing to what is currently supported.

