### PR TITLE
Follow NavLinks that do not match a registered route

### DIFF
--- a/examples/fluxible-router/components/Nav.js
+++ b/examples/fluxible-router/components/Nav.js
@@ -10,6 +10,9 @@ function Nav () {
         <ul className="pure-menu pure-menu-open pure-menu-horizontal">
             <li><NavLink routeName="home" activeStyle={{backgroundColor: '#ccc'}}>Home</NavLink></li>
             <li><NavLink routeName="about" activeStyle={{backgroundColor: '#ccc'}}>About</NavLink></li>
+            <li><NavLink href="/page/Relative" activeStyle={{backgroundColor: '#ccc'}}>Relative Href</NavLink></li>
+            <li><NavLink autoMatch={true} href="internal" activeStyle={{backgroundColor: '#ccc'}}>AutoMatch Href Internal</NavLink></li>
+            <li><NavLink autoMatch={true} href="//www.yahoo.com" activeStyle={{backgroundColor: '#ccc'}}>AutoMatch Href External</NavLink></li>
         </ul>
     );
 }

--- a/examples/fluxible-router/components/Nav.js
+++ b/examples/fluxible-router/components/Nav.js
@@ -11,8 +11,8 @@ function Nav () {
             <li><NavLink routeName="home" activeStyle={{backgroundColor: '#ccc'}}>Home</NavLink></li>
             <li><NavLink routeName="about" activeStyle={{backgroundColor: '#ccc'}}>About</NavLink></li>
             <li><NavLink href="/page/Relative" activeStyle={{backgroundColor: '#ccc'}}>Relative Href</NavLink></li>
-            <li><NavLink autoMatch={true} href="internal" activeStyle={{backgroundColor: '#ccc'}}>AutoMatch Href Internal</NavLink></li>
-            <li><NavLink autoMatch={true} href="//www.yahoo.com" activeStyle={{backgroundColor: '#ccc'}}>AutoMatch Href External</NavLink></li>
+            <li><NavLink validate={true} href="/internalPage" activeStyle={{backgroundColor: '#ccc'}}>Validate Href Internal</NavLink></li>
+            <li><NavLink validate={true} href="//www.yahoo.com" activeStyle={{backgroundColor: '#ccc'}}>Validate Href External</NavLink></li>
         </ul>
     );
 }

--- a/examples/fluxible-router/configs/routes.js
+++ b/examples/fluxible-router/configs/routes.js
@@ -23,6 +23,17 @@ export default {
             done();
         }
     },
+    internal: {
+        path: '/internalPage',
+        method: 'get',
+        handler: require('../components/Page'),
+        label: 'Internal',
+        action: (context, payload, done) => {
+            context.dispatch('LOAD_PAGE', { id: 'Internal Page' });
+            context.dispatch('UPDATE_PAGE_TITLE', { pageTitle: 'Internal Page | flux-examples | routing' });
+            done();
+        }
+    },
     dynamicpage: {
         path: '/page/:id',
         method: 'get',

--- a/examples/fluxible-router/configs/routes.js
+++ b/examples/fluxible-router/configs/routes.js
@@ -26,7 +26,7 @@ export default {
     internal: {
         path: '/internalPage',
         method: 'get',
-        handler: require('../components/Page'),
+        handler: Page,
         label: 'Internal',
         action: (context, payload, done) => {
             context.dispatch('LOAD_PAGE', { id: 'Internal Page' });

--- a/packages/fluxible-router/docs/api/NavLink.md
+++ b/packages/fluxible-router/docs/api/NavLink.md
@@ -14,7 +14,12 @@ in navigation events.
 | replaceState | boolean, default to false | If set to true, replaceState is being used instead of pushState |
 | preserveScrollPosition | boolean, default to false | If set to true, the page will maintain its scroll position while change to new route.  This is useful for cases like on e-commerce site where user might want to change a product size.  The url will change, but the scroll position needs to remain the same. |
 | stopPropagation | boolean, default to false | If set to true, the click event will not be propagated beyond the NavLink |
+| activeClass | string | Class to add to `className` when link is active |
+| activeStyle | object | Inline styles to merge with `style` when link is active |
 | activeElement | string or React.Component| If specified, active NavLink components will use this component instead of 'a' tags |
+| validate | boolean, default to false | Useful when it is unknown whether a link matches a registered route, this 
+will validate the path before executing the navigation action. If the link does not match a registered route, it will 
+let the browser handle the navigation. |
 
 
 ## Example Usage

--- a/packages/fluxible-router/lib/createNavLinkComponent.js
+++ b/packages/fluxible-router/lib/createNavLinkComponent.js
@@ -37,7 +37,8 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             navParams: React.PropTypes.object,
             followLink: React.PropTypes.bool,
             preserveScrollPosition: React.PropTypes.bool,
-            replaceState: React.PropTypes.bool
+            replaceState: React.PropTypes.bool,
+            autoMatch: React.PropTypes.bool
         },
         getInitialState: function () {
             return this._getState(this.props);
@@ -88,6 +89,9 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             var routeName = props.routeName;
             var routeStore = this.context.getStore(RouteStore);
             var navParams = this.getNavParams(props);
+            if(props.autoMatch && href) {
+                href = routeStore.makePath(href, navParams) || href;
+            }
             if (!href && routeName) {
                 href = routeStore.makePath(routeName, navParams);
             }
@@ -108,6 +112,7 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             var navParams = this.getNavParams(this.props);
             var navType = this.props.replaceState ? 'replacestate' : 'click';
             var shouldFollowLink = this.shouldFollowLink(this.props);
+            var routeStore = this.context.getStore(RouteStore);
             debug('dispatchNavAction: action=NAVIGATE', this.props.href, shouldFollowLink, navParams);
             
             if (this.props.stopPropagation) {
@@ -132,7 +137,7 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
                 return;
             }
 
-            if (href[0] !== '/') {
+            if (href[0] !== '/' || (this.props.autoMatch && !routeStore.getRoute(href))) {
                 // this is not a relative url. check for external urls.
                 var location = window.location;
                 var origin = location.origin || (location.protocol + '//' + location.host);

--- a/packages/fluxible-router/lib/createNavLinkComponent.js
+++ b/packages/fluxible-router/lib/createNavLinkComponent.js
@@ -38,7 +38,7 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             followLink: React.PropTypes.bool,
             preserveScrollPosition: React.PropTypes.bool,
             replaceState: React.PropTypes.bool,
-            autoMatch: React.PropTypes.bool
+            validate: React.PropTypes.bool
         },
         getInitialState: function () {
             return this._getState(this.props);
@@ -89,9 +89,6 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             var routeName = props.routeName;
             var routeStore = this.context.getStore(RouteStore);
             var navParams = this.getNavParams(props);
-            if(props.autoMatch && href) {
-                href = routeStore.makePath(href, navParams) || href;
-            }
             if (!href && routeName) {
                 href = routeStore.makePath(routeName, navParams);
             }
@@ -114,7 +111,7 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             var shouldFollowLink = this.shouldFollowLink(this.props);
             var routeStore = this.context.getStore(RouteStore);
             debug('dispatchNavAction: action=NAVIGATE', this.props.href, shouldFollowLink, navParams);
-            
+
             if (this.props.stopPropagation) {
                 e.stopPropagation();
             }
@@ -137,7 +134,7 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
                 return;
             }
 
-            if (href[0] !== '/' || (this.props.autoMatch && !routeStore.getRoute(href))) {
+            if (href[0] !== '/') {
                 // this is not a relative url. check for external urls.
                 var location = window.location;
                 var origin = location.origin || (location.protocol + '//' + location.host);
@@ -149,6 +146,10 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
                 }
 
                 href = href.substring(origin.length) || '/';
+            }
+
+            if (this.props.validate && !routeStore.getRoute(href)) {
+                return;
             }
 
             e.preventDefault();

--- a/packages/fluxible-router/tests/unit/lib/NavLink-test.js
+++ b/packages/fluxible-router/tests/unit/lib/NavLink-test.js
@@ -111,34 +111,6 @@ describe('NavLink', function () {
             expect(ReactDOM.findDOMNode(link).getAttribute('href')).to.equal('/internal');
         });
 
-        it('should create href from attribute href when autoMatch is true', function () {
-            var link = ReactTestUtils.renderIntoDocument(
-                <MockAppComponent context={mockContext}>
-                    <NavLink autoMatch={true} href='int' />
-                </MockAppComponent>
-            );
-            expect(ReactDOM.findDOMNode(link).getAttribute('href')).to.equal('/internal');
-        });
-
-        it('should not have correct mapping from attribute href when autoMatch is false', function () {
-            var link = ReactTestUtils.renderIntoDocument(
-                <MockAppComponent context={mockContext}>
-                    <NavLink href='int' />
-                </MockAppComponent>
-            );
-            expect(ReactDOM.findDOMNode(link).getAttribute('href')).to.not.equal('/internal');
-        });
-
-        it('should create href from href and parameters when autoMatch is true', function () {
-            var navParams = {a: 1};
-            var link = ReactTestUtils.renderIntoDocument(
-                <MockAppComponent context={mockContext}>
-                    <NavLink autoMatch={true} href='fooA' navParams={navParams} />
-                </MockAppComponent>
-            );
-            expect(ReactDOM.findDOMNode(link).getAttribute('href')).to.equal('/foo/1');
-        });
-
         it('should throw if href and routeName undefined', function () {
             var navParams = {a: 1, b: 2};
             expect(function () {
@@ -283,11 +255,11 @@ describe('NavLink', function () {
             }, 10);
         });
 
-        it('context.executeAction called for href when autoMatch is true and href is registered', function (done) {
+        it('context.executeAction called for href when validate is true and href is registered', function (done) {
             var navParams = {a: 1, b: true};
             var link = ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext}>
-                    <NavLink autoMatch={true} href='int' navParams={navParams}/>
+                    <NavLink validate={true} href='/internal' navParams={navParams}/>
                 </MockAppComponent>
             );
             ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link), {button: 0});
@@ -301,10 +273,10 @@ describe('NavLink', function () {
             }, 10);
         });
 
-        it('context.executeAction not called for href when autoMatch is false', function (done) {
+        it('context.executeAction not called for external href when validate is true', function (done) {
             var link = ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext}>
-                    <NavLink href='int'/>
+                    <NavLink href='/external' validate={true}/>
                 </MockAppComponent>
             );
             ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link), {button: 0});
@@ -314,10 +286,26 @@ describe('NavLink', function () {
             }, 10);
         });
 
-        it('context.executeAction not called for href when autoMatch is true but href is not registered', function (done) {
+        it('context.executeAction called for external href when validate is false', function (done) {
             var link = ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext}>
-                    <NavLink autoMatch={true} href='notregister'/>
+                    <NavLink href='/external'/>
+                </MockAppComponent>
+            );
+            ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link), {button: 0});
+            window.setTimeout(function () {
+                expect(mockContext.executeActionCalls.length).to.equal(1);
+                expect(mockContext.executeActionCalls[0].action).to.equal(navigateAction);
+                expect(mockContext.executeActionCalls[0].payload.type).to.equal('click');
+                expect(mockContext.executeActionCalls[0].payload.url).to.equal('/external');
+                done();
+            }, 10);
+        });
+
+        it('context.executeAction not called for href when validate is true but href is not registered', function (done) {
+            var link = ReactTestUtils.renderIntoDocument(
+                <MockAppComponent context={mockContext}>
+                    <NavLink validate={true} href='notregister'/>
                 </MockAppComponent>
             );
             ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link), {button: 0});
@@ -376,10 +364,10 @@ describe('NavLink', function () {
             }, 10);
         });
 
-        it('context.executeAction not called for external urls when autoMatch is true', function (done) {
+        it('context.executeAction not called for external urls when validate is true', function (done) {
             var link = ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext}>
-                    <NavLink autoMatch={true} href='http://domain.does.not.exist/foo' />
+                    <NavLink validate={true} href='http://domain.does.not.exist/foo' />
                 </MockAppComponent>
             );
             ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link), {button: 0});


### PR DESCRIPTION
Extension of #369.

This renames `autoMatch` to `validate` and removes the `makePath` execution on the `href` prop.