### PR TITLE
Update to routr ^1.0.0 and support query params in NavLink

### DIFF
--- a/packages/fluxible-router/lib/RouteStore.js
+++ b/packages/fluxible-router/lib/RouteStore.js
@@ -5,10 +5,7 @@
 'use strict';
 var createStore = require('fluxible/addons/createStore');
 var Router = require('routr');
-var queryString = require('query-string');
 var inherits = require('inherits');
-
-var searchPattern = /\?([^\#]*)/;
 
 var RouteStore = createStore({
     storeName: 'RouteStore',
@@ -73,7 +70,12 @@ var RouteStore = createStore({
     },
     _matchRoute: function (url, options) {
         var self = this;
-        var route = self.getRouter().getRoute(url, options);
+        var indexOfHash = url.indexOf('#');
+        var hashlessUrl = url;
+        if (-1 !== indexOfHash) {
+            hashlessUrl = url.substr(0, indexOfHash);
+        }
+        var route = self.getRouter().getRoute(hashlessUrl, options);
         if (!route) {
             return null;
         }
@@ -83,7 +85,7 @@ var RouteStore = createStore({
             url: route.url,
             params: route.params,
             navigate: route.navigate,
-            query: self._parseQueryString(route.url)
+            query: route.query
         });
 
         return newRoute;
@@ -94,16 +96,8 @@ var RouteStore = createStore({
 
         return url1 === url2;
     },
-    _parseQueryString: function (url) {
-        var matches = url.match(searchPattern);
-        var search;
-        if (matches) {
-            search = matches[1];
-        }
-        return (search && queryString.parse(search)) || {};
-    },
-    makePath: function (routeName, params) {
-        return this.getRouter().makePath(routeName, params);
+    makePath: function (routeName, params, query) {
+        return this.getRouter().makePath(routeName, params, query);
     },
     getCurrentRoute: function () {
         return this._currentRoute;

--- a/packages/fluxible-router/lib/createNavLinkComponent.js
+++ b/packages/fluxible-router/lib/createNavLinkComponent.js
@@ -35,6 +35,7 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             stopPropagation: React.PropTypes.bool,
             routeName: React.PropTypes.string,
             navParams: React.PropTypes.object,
+            queryParams: React.PropTypes.object,
             followLink: React.PropTypes.bool,
             preserveScrollPosition: React.PropTypes.bool,
             replaceState: React.PropTypes.bool,
@@ -89,8 +90,9 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             var routeName = props.routeName;
             var routeStore = this.context.getStore(RouteStore);
             var navParams = this.getNavParams(props);
+            var queryParams = this.getQueryParams(props);
             if (!href && routeName) {
-                href = routeStore.makePath(routeName, navParams);
+                href = routeStore.makePath(routeName, navParams, queryParams);
             }
             if (!href) {
                 throw new Error('NavLink created without href or unresolvable ' +
@@ -98,6 +100,9 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
                     JSON.stringify(navParams));
             }
             return href;
+        },
+        getQueryParams: function (props) {
+            return props.queryParams;
         },
         getNavParams: function (props) {
             return props.navParams;

--- a/packages/fluxible-router/package.json
+++ b/packages/fluxible-router/package.json
@@ -25,7 +25,7 @@
     "hoist-non-react-statics": "^1.0.4",
     "inherits": "^2.0.1",
     "query-string": "^3.0.0",
-    "routr": "^0.1.1"
+    "routr": "^1.0.0"
   },
   "peerDependencies": {
     "fluxible": "^1.0.0",

--- a/packages/fluxible-router/package.json
+++ b/packages/fluxible-router/package.json
@@ -24,7 +24,6 @@
     "fluxible-addons-react": "^0.2.0",
     "hoist-non-react-statics": "^1.0.4",
     "inherits": "^2.0.1",
-    "query-string": "^3.0.0",
     "routr": "^1.0.0"
   },
   "peerDependencies": {

--- a/packages/fluxible-router/tests/unit/lib/NavLink-test.js
+++ b/packages/fluxible-router/tests/unit/lib/NavLink-test.js
@@ -121,7 +121,15 @@ describe('NavLink', function () {
                 );
             }).to['throw']();
         });
-
+        it('should create href with query params', function () {
+            var queryParams = {a: 1, b: 2};
+            var link = ReactTestUtils.renderIntoDocument(
+                <MockAppComponent context={mockContext}>
+                    <NavLink routeName='foo' queryParams={queryParams} />
+                </MockAppComponent>
+            );
+            expect(ReactDOM.findDOMNode(link).getAttribute('href')).to.equal('/foo?a=1&b=2');
+        });
         it('should set active state if href matches current route', function () {
             var navParams = {a: 1, b: 2};
             var link = ReactTestUtils.renderIntoDocument(

--- a/packages/fluxible-router/tests/unit/lib/RouteStore-test.js
+++ b/packages/fluxible-router/tests/unit/lib/RouteStore-test.js
@@ -115,7 +115,7 @@ describe('RouteStore', function () {
                 url: '/bar',
                 method: 'get'
             });
-            expect(routeStore.getCurrentRoute().navigate.transactionId).to.equal('second');
+            expect(routeStore.getCurrentNavigate().transactionId).to.equal('second');
         });
         it('should update transactionId with same url navigation', function () {
             routeStore._handleNavigateStart({
@@ -123,7 +123,7 @@ describe('RouteStore', function () {
                 url: '/foo',
                 method: 'get'
             });
-            expect(routeStore.getCurrentRoute().navigate.transactionId).to.equal('second');
+            expect(routeStore.getCurrentNavigate().transactionId).to.equal('second');
         });
     });
 

--- a/packages/fluxible-router/tests/unit/lib/navigateAction-test.js
+++ b/packages/fluxible-router/tests/unit/lib/navigateAction-test.js
@@ -88,7 +88,7 @@ describe('navigateAction', function () {
             expect(route.query).to.eql({foo: 'bar', a: ['b', 'c'], bool: null}, 'query added to route payload for NAVIGATE_START' + JSON.stringify(route));
             expect(mockContext.dispatchCalls[1].name).to.equal('NAVIGATE_SUCCESS');
             route = mockContext.dispatchCalls[1].payload;
-            expect(route.url).to.equal(url);
+            expect(route.url).to.equal(url.split('#')[0]);
             done();
         });
     });

--- a/packages/fluxible-router/tests/unit/lib/navigateAction-test.js
+++ b/packages/fluxible-router/tests/unit/lib/navigateAction-test.js
@@ -106,13 +106,13 @@ describe('navigateAction', function () {
             expect(err).to.equal(undefined);
             expect(mockContext.dispatchCalls.length).to.equal(2);
             expect(mockContext.dispatchCalls[0].name).to.equal('NAVIGATE_START');
-            var route = mockContext.getStore('RouteStore').getCurrentRoute();
-            expect(route.navigate).to.eql({
+            var navigate = mockContext.getStore('RouteStore').getCurrentNavigate();
+            expect(navigate).to.eql({
                 transactionId: 'foo',
                 url: url,
                 someKey1: 'someData',
                 someKey2: {someKey3: ['a', 'b']}
-            }, 'navigate added to route payload for NAVIGATE_START' + JSON.stringify(route));
+            }, 'navigate added to route payload for NAVIGATE_START' + JSON.stringify(navigate));
             done();
         });
     });


### PR DESCRIPTION
This is a breaking change:

 * `route.navigate` no longer exists. The current navigate can be accessed from `RouteStore.getCurrentNavigate()`.
 * `NavLink` now supports `queryParams` prop for generating urls with query params