### PR TITLE
use the container display name convention used by recompose

### DIFF
--- a/packages/fluxible-addons-react/connectToStores.js
+++ b/packages/fluxible-addons-react/connectToStores.js
@@ -23,7 +23,7 @@ function createComponent(Component, stores, getStateFromStores, customContextTyp
 
     inherits(StoreConnector, React.Component);
 
-    StoreConnector.displayName = componentName + 'StoreConnector';
+    StoreConnector.displayName = 'storeConnector(' + componentName + ')';
     StoreConnector.contextTypes = componentContextTypes;
 
     Object.assign(StoreConnector.prototype, {

--- a/packages/fluxible-addons-react/provideContext.js
+++ b/packages/fluxible-addons-react/provideContext.js
@@ -21,7 +21,7 @@ function createComponent(Component, customContextTypes) {
 
     inherits(ContextProvider, React.Component);
 
-    ContextProvider.displayName = componentName + 'ContextProvider';
+    ContextProvider.displayName = 'contextProvider(' + componentName + ')';
     ContextProvider.propTypes = {
         context: React.PropTypes.object.isRequired
     };

--- a/packages/fluxible-addons-react/tests/unit/lib/provideContext.js
+++ b/packages/fluxible-addons-react/tests/unit/lib/provideContext.js
@@ -37,7 +37,7 @@ describe('fluxible-addons-react', function () {
             });
 
             var WrappedComponent = provideContext(Component);
-            expect(WrappedComponent.displayName).to.equal('ComponentContextProvider');
+            expect(WrappedComponent.displayName).to.equal('contextProvider(Component)');
         });
 
         it('should use the childs displayName', function () {
@@ -49,7 +49,7 @@ describe('fluxible-addons-react', function () {
             });
 
             var WrappedComponent = provideContext(Component);
-            expect(WrappedComponent.displayName).to.equal('TestComponentContextProvider');
+            expect(WrappedComponent.displayName).to.equal('contextProvider(TestComponent)');
         });
 
         it('should provide the context with custom types to children', function () {


### PR DESCRIPTION
https://github.com/acdlite/recompose/blob/master/docs/API.md#wrapdisplayname

I don't really prefer one convention over another, but combining both has resulted in some pretty weird displayNames. this would just make my debugging life a tad easier :)