### PR TITLE
[router] Inverts the navigate completion event payload

### DIFF
--- a/packages/fluxible-router/tests/unit/lib/RouteStore-test.js
+++ b/packages/fluxible-router/tests/unit/lib/RouteStore-test.js
@@ -31,12 +31,10 @@ describe('RouteStore', function () {
             it('should dehydrate correctly', function () {
                 var state = routeStore.dehydrate();
                 expect(state).to.be.an('object');
-                expect(state.currentUrl).to.equal('/foo');
-                expect(state.currentNavigate).to.deep.equal({
-                    transactionId: 'first',
-                    url: '/foo',
-                    method: 'get'
-                });
+                expect(state.currentNavigate).to.be.an('object');
+                expect(state.currentNavigate.transactionId).to.equal('first');
+                expect(state.currentNavigate.url).to.equal('/foo');
+                expect(state.currentNavigate.method).to.equal('get');
                 expect(state.routes).to.equal(null);
             });
         });
@@ -49,11 +47,9 @@ describe('RouteStore', function () {
                     routes: null
                 });
                 expect(newStore.getCurrentRoute()).to.be.an('object');
-                expect(newStore.getCurrentNavigate()).to.deep.equal({
-                    transactionId: 'first',
-                    url: '/foo',
-                    method: 'get'
-                });
+                expect(newStore.getCurrentNavigate().transactionId).to.equal('first');
+                expect(newStore.getCurrentNavigate().url).to.equal('/foo');
+                expect(newStore.getCurrentNavigate().method).to.equal('get');
                 expect(newStore._routes).to.equal(null);
             });
         });
@@ -72,19 +68,19 @@ describe('RouteStore', function () {
             });
             expect(routeStore.isNavigateComplete()).to.equal(false);
             routeStore._handleNavigateSuccess({
-                navigate: {
-                    transactionId: 'first'
-                },
-                url: '/bar',
-                method: 'get'
+                transactionId: 'first',
+                route: {
+                    url: '/bar',
+                    method: 'get'
+                }
             });
             expect(routeStore.isNavigateComplete()).to.equal(false);
             routeStore._handleNavigateSuccess({
-                navigate: {
-                    transactionId: 'second'
-                },
-                url: '/bar',
-                method: 'get'
+                transactionId: 'second',
+                route: {
+                    url: '/bar',
+                    method: 'get'
+                }
             });
             expect(routeStore.isNavigateComplete()).to.equal(true);
         });
@@ -98,14 +94,18 @@ describe('RouteStore', function () {
             expect(routeStore.isNavigateComplete()).to.equal(false);
             routeStore._handleNavigateFailure({
                 transactionId: 'first',
-                statusCode: 404,
-                message: 'Url /unknown does not match any routes'
+                error: {
+                    statusCode: 404,
+                    message: 'Url /unknown does not match any routes'
+                }
             });
             expect(routeStore.isNavigateComplete()).to.equal(false);
             routeStore._handleNavigateFailure({
                 transactionId: 'second',
-                statusCode: 404,
-                message: 'Url /unknown does not match any routes'
+                error: {
+                    statusCode: 404,
+                    message: 'Url /unknown does not match any routes'
+                }
             });
             expect(routeStore.isNavigateComplete()).to.equal(true);
         });
@@ -151,11 +151,8 @@ describe('RouteStore', function () {
             it('should dehydrate correctly', function () {
                 var state = routeStore.dehydrate();
                 expect(state).to.be.an('object');
-                expect(state.currentUrl).to.equal('/foo');
-                expect(state.currentNavigate).to.deep.equal({
-                    url: '/foo',
-                    method: 'get'
-                });
+                expect(state.currentNavigate.url).to.equal('/foo');
+                expect(state.currentNavigate.method).to.equal('get');
                 expect(state.routes).to.deep.equal(routes);
             });
         });
@@ -168,25 +165,20 @@ describe('RouteStore', function () {
                     routes: routes
                 });
                 expect(newStore.getCurrentRoute()).to.be.an('object');
-                expect(newStore.getCurrentNavigate()).to.deep.equal({
-                    url: '/foo',
-                    method: 'get'
-                });
+                expect(newStore.getCurrentNavigate().url).to.equal('/foo');
+                expect(newStore.getCurrentNavigate().method).to.equal('get');
                 expect(newStore._routes).to.deep.equal(routes);
             });
 
             it('should rehydrate POST routes correctly', function() {
                 var newStore = new StaticRouteStore();
                 newStore.rehydrate({
-                    currentUrl: '/bar',
                     currentNavigate: { url: '/bar', method: 'post' },
                     routes: routes
                 });
                 expect(newStore.getCurrentRoute()).to.be.an('object');
-                expect(newStore.getCurrentNavigate()).to.deep.equal({
-                    url: '/bar',
-                    method: 'post'
-                });
+                expect(newStore.getCurrentNavigate().url).to.equal('/bar');
+                expect(newStore.getCurrentNavigate().method).to.equal('post');
                 expect(newStore._routes).to.deep.equal(routes);
             });
         });

--- a/packages/fluxible-router/tests/unit/lib/navigateAction-test.js
+++ b/packages/fluxible-router/tests/unit/lib/navigateAction-test.js
@@ -87,32 +87,31 @@ describe('navigateAction', function () {
             var route = mockContext.getStore('RouteStore').getCurrentRoute();
             expect(route.query).to.eql({foo: 'bar', a: ['b', 'c'], bool: null}, 'query added to route payload for NAVIGATE_START' + JSON.stringify(route));
             expect(mockContext.dispatchCalls[1].name).to.equal('NAVIGATE_SUCCESS');
-            route = mockContext.dispatchCalls[1].payload;
-            expect(route.url).to.equal(url.split('#')[0]);
+            var navigateSuccessPayload = mockContext.dispatchCalls[1].payload;
+            expect(navigateSuccessPayload.route.url).to.equal(url.split('#')[0]);
             done();
         });
     });
 
     it('should include navigate object on route match', function (done) {
         var url = '/';
-        navigateAction(mockContext, {
+        var nav = {
             transactionId: 'foo',
             url: url,
             someKey1: 'someData',
             someKey2: {
                 someKey3: ['a', 'b']
             }
-        }, function (err) {
+        };
+        navigateAction(mockContext, nav, function (err) {
             expect(err).to.equal(undefined);
             expect(mockContext.dispatchCalls.length).to.equal(2);
             expect(mockContext.dispatchCalls[0].name).to.equal('NAVIGATE_START');
             var navigate = mockContext.getStore('RouteStore').getCurrentNavigate();
-            expect(navigate).to.eql({
-                transactionId: 'foo',
-                url: url,
-                someKey1: 'someData',
-                someKey2: {someKey3: ['a', 'b']}
-            }, 'navigate added to route payload for NAVIGATE_START' + JSON.stringify(navigate));
+            expect(navigate).to.be.an('object');
+            Object.keys(nav).forEach(function (navKey) {
+                expect(navigate[navKey]).to.eql(nav[navKey]);
+            });
             done();
         });
     });


### PR DESCRIPTION
This structures the RouteStore state such that the navigate object contains the relevant metadata: route, error, isComplete. This allows us to get closer to an immutable store, but does change the object that is received by NAVIGATE_SUCCESS and NAVIGATE_FAILURE events:

 * NAVIGATE_SUCCESS received the route objet which contained `navigate`, but that is no longer the case. In order to relate the SUCCESS to the START event, it is required to pass in a `navigate` object instead.

 * NAVIGATE_FAILURE received an error object, but to maintain the similar interface to SUCCESS, this has been updated to the navigate object that contains addtional error information.