### PR TITLE
Release fluxible-router@1.0.0-alpha.1

### DIFF
--- a/packages/fluxible-router/CHANGELOG.md
+++ b/packages/fluxible-router/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change Log
 
+## 1.0.0-alpha.1
+
+### Breaking Changes
+
+See the [upgrade guide](UPGRADE.md#04x-to-1x)
+
+ * Default `activeClass` prop has been removed
+ * `route` object no longer contains `navigate` key. `navigate` can be accessed via `routeStore.getCurrentNavigate()`
+ * `NAVIGATE_SUCCESS` and `NAVIGATE_FAILURE` payloads are now the `navigate` object which contains a `route` key to
+ access the current route.
+
+### Features
+
+ * Performance improvements:
+ ** `NavLink` will only listen to the `RouteStore` if an `active*` property is used.
+ ** `NavLink` will no longer compute active state on all prop/state changes, only when `currentRoute` or `prop` has 
+ changed.
+ * [#397] NavLink now supports query parameters via the `queryParams` property
+
 ## 0.4.11
 
 ### Features

--- a/packages/fluxible-router/UPGRADE.md
+++ b/packages/fluxible-router/UPGRADE.md
@@ -1,5 +1,38 @@
 # Upgrade Guide
 
+## 0.4.x to 1.x
+
+### NavLink's default `activeClass` prop value removed
+
+Previously all `NavLink`s listened the `RouteStore` for changes in order to update their active style/class/element. 
+In many cases none of these properties were used, which meant the component was listening unnecessarily. Now 
+`NavLink` will only listen if `activeClass`, `activeStyle`, or `activeElement` are explicitly passed in to the 
+component.
+
+Code that relied on the `active` class to be automatically added to `NavLink` components will be required to 
+explicitly use `<NavLink activeClass='active'>` in order for the link to listen for updates.
+
+### `route.navigate` no longer exists
+
+Code that relied on `route.navigate` will need to access the `navigate` object from `RouteStore.getCurrentNavigate()`
+. The ownership of these two objects have been inverted to reflect that a navigation results in a route being matched
+rather than the inverse. This allows us to optimize `NavLink` by making `navigate` and `route` immutable and 
+recognize that a `navigate` may be triggered, but the `route` doesn't necessarily change.
+
+### `NAVIGATE_SUCCESS` and `NAVIGATE_FAILURE` payload changes
+
+Stores that listen to `NAVIGATE_SUCCESS` and `NAVIGATE_FAILURE` will receive a different payload. These payloads have
+been unified across the events. This allows the `RouteStore` to correlate the events with `NAVIGATE_START` using a 
+transaction identifier with the changes to the `route` object.
+
+#### `NAVIGATE_SUCCESS`
+
+Previously received the `route` object, but now receives the `navigate` object which contains `navigate.route`.
+
+#### `NAVIGATE_FAILURE`
+
+Previously received an `error` object, but now receives the `navigate` object which contains `navigate.error`.
+
 ## 0.3.x to 0.4.x
 
 The `RouteStore`s `currentRoute` is no longer an immutable.js object. 


### PR DESCRIPTION
Adds upgrade guide and release notes. Once this is merged I will publish 1.0.0-alpha.1 to the `next` branch.