### PR TITLE
[resolves #405] Remove `payload` parameter in BaseStore.emitChange

### DIFF
--- a/packages/dispatchr/addons/BaseStore.js
+++ b/packages/dispatchr/addons/BaseStore.js
@@ -65,11 +65,10 @@ BaseStore.prototype.shouldDehydrate = function shouldDehydrate() {
 /**
  * Emit a change event
  * @method emitChange
- * @param {*} param=this
  */
-BaseStore.prototype.emitChange = function emitChange(param) {
+BaseStore.prototype.emitChange = function emitChange() {
     this._hasChanged = true;
-    this.emit(CHANGE_EVENT, param || this);
+    this.emit(CHANGE_EVENT, this);
 };
 
 module.exports = BaseStore;

--- a/packages/dispatchr/tests/unit/addons/BaseStore.js
+++ b/packages/dispatchr/tests/unit/addons/BaseStore.js
@@ -22,13 +22,9 @@ describe('BaseStore', function () {
 
     it('allows listening for changes', function (done) {
         var store = new BaseStore(dispatcherMock);
-        var payloadMock = {
-            foo: 'bar'
-        };
-        store.addChangeListener(function (payload) {
-            expect(payload.foo).to.equal('bar');
+        store.addChangeListener(function () {
             done();
         });
-        store.emitChange(payloadMock);
+        store.emitChange();
     });
 });


### PR DESCRIPTION
See #405.
