### PR TITLE
Add query in some missing places

### DIFF
--- a/packages/fluxible-router/lib/handleHistory.js
+++ b/packages/fluxible-router/lib/handleHistory.js
@@ -170,7 +170,9 @@ function createComponent(Component, opts) {
             var confirmResult = onBeforeUnloadText ? window.confirm(onBeforeUnloadText) : true;
 
             var navParams = nav.params || {};
+            var navQuery = nav.query || {};
             var historyState = {
+                query: navQuery,
                 params: navParams,
                 scroll: {
                     x: window.scrollX,
@@ -193,7 +195,8 @@ function createComponent(Component, opts) {
                     this.context.executeAction(navigateAction, {
                         type: TYPE_POPSTATE,
                         url: url,
-                        params: (e.state && e.state.params)
+                        params: (e.state && e.state.params),
+                        query: (e.state && e.state.query),
                     });
                 }
             }
@@ -218,6 +221,7 @@ function createComponent(Component, opts) {
             var nav = this.props.currentNavigate || {};
             var navType = nav.type || TYPE_DEFAULT;
             var navParams = nav.params || {};
+            var navQuery = nav.query || {};
             var historyState;
 
             switch (navType) {
@@ -227,7 +231,7 @@ function createComponent(Component, opts) {
                     if (nav.url === this._history.getUrl()) {
                         return;
                     }
-                    historyState = {params: navParams};
+                    historyState = {params: navParams, query: navQuery};
                     if (nav.preserveScrollPosition) {
                         historyState.scroll = {x: window.scrollX, y: window.scrollY};
                     } else {

--- a/packages/fluxible-router/lib/navigateAction.js
+++ b/packages/fluxible-router/lib/navigateAction.js
@@ -12,7 +12,7 @@ function navigateAction (context, payload, done) {
         transactionId: context.rootId
     }, payload);
     if (!payload.url && payload.routeName) {
-        navigate.url = routeStore.makePath(payload.routeName, payload.params);
+        navigate.url = routeStore.makePath(payload.routeName, payload.params, payload.query);
         navigate.routeName = null;
     }
 


### PR DESCRIPTION
I was trying to do some advanced routing and I found out a few places it looks like the query might be useful.

Turns out I managed to do what I need without this changes. But I do think this might be a good idea for fluxible-router 1.0.0 because now you support query string on the NavLink. Suppose a user uses NavLink with the same route params, the history might be badly handled.

Feel free to close the Pull Request if this is not useful or if it is a mistake. I didn't fully test but this was the easier way to send a diff of the changes I wanted to suggest.