### PR TITLE
Updates to routr 2.0.0

### DIFF
--- a/packages/fluxible-router/CHANGELOG.md
+++ b/packages/fluxible-router/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.0.0-alpha.4
+
+### Breaking Changes
+
+ * [#417] Updates to routr 2.0.0. `getRoute` will now `decodeURIComponent` route values, you might need to remove `decodeURIComponent` from your route actions if you were supporting extended characters manually in your routes.
+
 ## 1.0.0-alpha.3
 
 ### Bug Fixes
@@ -28,7 +34,7 @@ See the [upgrade guide](UPGRADE.md#04x-to-1x)
 
  * Performance improvements:
  ** `NavLink` will only listen to the `RouteStore` if an `active*` property is used.
- ** `NavLink` will no longer compute active state on all prop/state changes, only when `currentRoute` or `prop` has 
+ ** `NavLink` will no longer compute active state on all prop/state changes, only when `currentRoute` or `prop` has
  changed.
  * [#397] NavLink now supports query parameters via the `queryParams` property
 
@@ -48,7 +54,7 @@ See the [upgrade guide](UPGRADE.md#04x-to-1x)
 
  * [#390] Support for React 15
  * [#394] Allow ignoring popstate event on page load
- 
+
 ### Bug Fixes
 
  * [#392] Fix stopPropagation not working with modified key presses
@@ -130,7 +136,7 @@ Deprecated, published package was corrupted
 
  * Upgraded to React 0.14, breaking compatibility with older versions of React
  * Removed dependency on `Object.assign` library, must be polyfilled
- 
+
 ### Features
 
  * [#69] Add NavLink `activeElement` option to use another element type for active state

--- a/packages/fluxible-router/package.json
+++ b/packages/fluxible-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluxible-router",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "description": "Routing for Fluxible applications",
   "main": "index.js",
   "repository": {
@@ -24,7 +24,7 @@
     "fluxible-addons-react": "^0.2.0",
     "hoist-non-react-statics": "^1.0.4",
     "inherits": "^2.0.1",
-    "routr": "^1.0.0"
+    "routr": "^2.0.0"
   },
   "peerDependencies": {
     "fluxible": "^1.0.0",


### PR DESCRIPTION
This expects https://github.com/yahoo/routr/pull/33 to be merged before merging this one.

I tested and everything works correctly and tests pass when linking the correct versions. Let me know if you want redundant tests to be added here for this particular use case or if keeping in the routr is good enough. IMHO it should be fine to just bump versions.