### PR TITLE
Remove unused variables

### DIFF
--- a/packages/fluxible/lib/FluxibleContext.js
+++ b/packages/fluxible/lib/FluxibleContext.js
@@ -33,8 +33,6 @@ function FluxContext(app) {
     this._storeContext = null;
 }
 
-var warnedOnce = false;
-
 /**
  * Getter for the app's component. Pass through to the Fluxible instance.
  * @method getComponent


### PR DESCRIPTION
`warnedOnce` was used for deprecation warnings which have all been removed.