### PR TITLE
provide overwriting getDefaultChildProps

### DIFF
--- a/packages/fluxible-router/lib/createNavLinkComponent.js
+++ b/packages/fluxible-router/lib/createNavLinkComponent.js
@@ -118,12 +118,38 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             }
             return href;
         },
-        getQueryParams: function (props) {
-            return props.queryParams;
+        /**
+         * Default getDefaultChildProps function, return empty object
+         * @method getDefaultChildProps
+         * @return {Object} default child props
+         */
+        getDefaultChildProps: function () {
+            return {};
         },
+        /**
+         * Default getNavParams function, return props.navParams
+         * @method getNavParams
+         * @param {Object} props props object
+         * @return {Object} nav params
+         */
         getNavParams: function (props) {
             return props.navParams;
         },
+        /**
+         * Default getQueryParams function, return props.queryParams
+         * @method getQueryParams
+         * @param {Object} props props object
+         * @return {Object} query params
+         */
+        getQueryParams: function (props) {
+            return props.queryParams;
+        },
+        /**
+         * Default shouldFollowLink, return props.followLink
+         * @method shouldFollowLink
+         * @param {Object} props props object
+         * @return {Boolean} should follow link value
+         */
         shouldFollowLink: function(props) {
             return props.followLink;
         },
@@ -216,7 +242,7 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
                 }
             }
 
-            var childProps = {};
+            var childProps = this.getDefaultChildProps();
 
             if (!(isActive && this.props.activeElement)) {
                 childProps.onClick = this.clickHandler.bind(this);

--- a/packages/fluxible-router/tests/unit/lib/NavLink-test.js
+++ b/packages/fluxible-router/tests/unit/lib/NavLink-test.js
@@ -191,6 +191,21 @@ describe('NavLink', function () {
             );
             expect(ReactDOM.findDOMNode(link).getAttribute('class')).to.equal(null);
         });
+        
+        it('should able to get additional child props by dynamical getDefaultChildProps function', function () {
+            var navLink = React.createElement(createNavLinkComponent({
+                getDefaultChildProps: function () {
+                    return {'data-foo': 'foo', 'data-bar': 'bar'};
+                }
+            }), {routeName: 'foo'});
+            var link = ReactTestUtils.renderIntoDocument(
+                <MockAppComponent context={mockContext}>
+                    {navLink}
+                </MockAppComponent>
+            );
+            expect(ReactDOM.findDOMNode(link).getAttribute('data-foo')).to.equal('foo');
+            expect(ReactDOM.findDOMNode(link).getAttribute('data-bar')).to.equal('bar');
+        });
     });
 
     describe('dispatchNavAction()', function () {


### PR DESCRIPTION
@mridgway @redonkulus @Vijar 

this adds the ability to dynamically decide the additional child props without wrap NavLink with another component.

also add JSDoc for all these functions with the same usage.