### PR TITLE
Catch pushState and replaceState exceptions

### DIFF
--- a/packages/fluxible-router/lib/History.js
+++ b/packages/fluxible-router/lib/History.js
@@ -103,7 +103,11 @@ History.prototype = {
 
             // remember the original url in state, so that it can be used by getUrl()
             var _state = Object.assign({origUrl: url}, state);
-            win.history.pushState(_state, title, url);
+            try {
+                win.history.pushState(_state, title, url);
+            } catch (_) {
+                win.location.href = url;
+            }
             this.setTitle(title);
         } else if (url) {
             win.location.href = url;
@@ -125,7 +129,11 @@ History.prototype = {
 
             // remember the original url in state, so that it can be used by getUrl()
             var _state = Object.assign({origUrl: url}, state);
-            win.history.replaceState(_state, title, url);
+            try {
+                win.history.replaceState(_state, title, url);
+            } catch(_) {
+                win.location.replace(url);
+            }
             this.setTitle(title);
         } else if (url) {
             win.location.replace(url);


### PR DESCRIPTION
Webkit on IOS throws exception: "SecurityError: DOM Exception 18" after many (~50) history changes.

Catch this error and failback to old method of url changing.