### PR TITLE
Ability to inspect dispatch calls as well as action/dispatch payloads

### DIFF
--- a/packages/fluxible-plugin-devtools/src/components/ActionTree.jsx
+++ b/packages/fluxible-plugin-devtools/src/components/ActionTree.jsx
@@ -159,24 +159,8 @@ class ActionTree extends React.Component {
                 .style('fill', color)
                 .on('click', toggleCollapse)
                 .on('mouseover', showCurrentPath)
-                .on('mouseout', showAllPaths);
-
-            nodeEnter.append('rect')
-                .attr('class', 'log')
-                .attr('height', barHeight)
-                .attr('width', barHeight)
-                .attr('y', -barHeight/2)
-                .attr('x', d => d.x)
-                .on('click', log);
-            nodeEnter.append('text')
-                .attr('class', 'payload-label')
-                .attr('height', barHeight)
-                .attr('width', barHeight)
-                .attr('dy', '3.5')
-                .attr('dx', '1.5')
-                .attr('x', d => d.x)
-                .text('{...}')
-                .on('click', log);
+                .on('mouseout', showAllPaths)
+                .append('title').text(d => 'Click to collapse ' + d.name +'. Hover to see path to parent.');
             nodeEnter.append('text')
                 .attr('class', 'displayLabel')
                 .attr('dy', 3.5)
@@ -186,6 +170,23 @@ class ActionTree extends React.Component {
                 .on('click', toggleCollapse)
                 .on('mouseover', showCurrentPath)
                 .on('mouseout', showAllPaths);
+
+            nodeEnter.append('text')
+                .attr('class', 'payload-label')
+                .attr('height', barHeight)
+                .attr('width', barHeight)
+                .attr('dy', '3.5')
+                .attr('dx', '2')
+                .attr('x', d => d.x)
+                .text('{...}');
+            nodeEnter.append('rect')
+                .attr('class', 'log')
+                .attr('height', barHeight)
+                .attr('width', barHeight)
+                .attr('y', -barHeight/2)
+                .attr('x', d => d.x)
+                .on('click', log)
+                .append('title').text(d => 'Open your javascript console and click here to inspect the payload of ' + d.name);
 
             // Transition nodes to their new position.
             nodeEnter.transition()

--- a/packages/fluxible-plugin-devtools/src/components/Actions.jsx
+++ b/packages/fluxible-plugin-devtools/src/components/Actions.jsx
@@ -13,6 +13,6 @@ export default class Actions extends React.Component {
     render() {
         var actions = this.context.devtools.getActionHistory()
             .map(action => <ActionTree {...this.props} action={action} key={action.rootId} />);
-        return <div>{actions}</div>;
+        return (<div>{actions}</div>);
     }
 };

--- a/packages/fluxible-plugin-devtools/src/lib/CONSTANTS.js
+++ b/packages/fluxible-plugin-devtools/src/lib/CONSTANTS.js
@@ -1,0 +1,2 @@
+export const ACTION = 'action';
+export const DISPATCH = 'dispatch';


### PR DESCRIPTION
Tasks:
- [x] Add a `{...}` button which will output the payload to console
- [x] Allow ability to trace dispatch calls via `showDispatchCalls` prop
- [x] Hover on node, will show the link to it's parent action
- [x] Hover on `{...}` should show tooltip telling users to open console and click the `{...}` button
