### PR TITLE
Point to #flux channel on Reactiflux

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository is the home of [Fluxible](http://fluxible.io/) and related libraries.
 
-Join the #fluxible channel of the [Reactiflux](http://reactiflux.com) Discord community.
+Join the #flux channel of the [Reactiflux](https://discord.gg/0ZcbPKXt5bYedEbN) Discord community.
 
 ## Development
 


### PR DESCRIPTION
Discord has bad channel management, and as the #fluxible doesn't see much traffic, we're trying to point users where they're more likely to get some kind of answer. Also make it an instant join link so they're directed directly to the room.