### PR TITLE
disable onScroll changeState

### DIFF
--- a/packages/fluxible-router/lib/handleHistory.js
+++ b/packages/fluxible-router/lib/handleHistory.js
@@ -131,7 +131,9 @@ function createComponent(Component, opts) {
                 }
             }
 
-            window.addEventListener('scroll', this._onScroll);
+            if (oprions.enableScroll) {
+                window.addEventListener('scroll', this._onScroll);
+            }
         },
         _onScroll: function (e) {
             if (this._scrollTimer) {
@@ -173,12 +175,15 @@ function createComponent(Component, opts) {
             var navQuery = nav.query || {};
             var historyState = {
                 query: navQuery,
-                params: navParams,
-                scroll: {
+                params: navParams
+            };
+
+            if (oprions.enableScroll) {
+                historyState.scroll = {
                     x: window.scrollX || window.pageXOffset,
                     y: window.scrollY || window.pageYOffset
-                }
-            };
+                };
+            }
 
             var pageTitle = navParams.pageTitle || null;
 
@@ -214,7 +219,9 @@ function createComponent(Component, opts) {
         componentWillUnmount: function () {
             this._history.off(this._onHistoryChange);
 
-            window.removeEventListener('scroll', this._onScroll);
+            if (oprions.enableScroll) {
+                window.removeEventListener('scroll', this._onScroll);
+            }
 
             historyCreated = false;
         },
@@ -235,17 +242,17 @@ function createComponent(Component, opts) {
                         return;
                     }
                     historyState = {params: navParams, query: navQuery};
-                    if (nav.preserveScrollPosition) {
-                        historyState.scroll = {
-                            x: window.scrollX || window.pageXOffset,
-                            y: window.scrollY || window.pageYOffset
-                        };
-                    } else {
-                        if (options.enableScroll) {
+                    if (oprions.enableScroll) {
+                        if (nav.preserveScrollPosition) {
+                            historyState.scroll = {
+                                x: window.scrollX || window.pageXOffset,
+                                y: window.scrollY || window.pageYOffset
+                            };
+                        } else {
                             window.scrollTo(0, 0);
                             debug('on click navigation, reset scroll position to (0, 0)');
+                            historyState.scroll = {x: 0, y: 0};
                         }
-                        historyState.scroll = {x: 0, y: 0};
                     }
                     var pageTitle = navParams.pageTitle || null;
                     if (navType === TYPE_REPLACESTATE) {

--- a/packages/fluxible-router/lib/handleHistory.js
+++ b/packages/fluxible-router/lib/handleHistory.js
@@ -131,7 +131,7 @@ function createComponent(Component, opts) {
                 }
             }
 
-            if (oprions.enableScroll) {
+            if (options.enableScroll) {
                 window.addEventListener('scroll', this._onScroll);
             }
         },
@@ -178,7 +178,7 @@ function createComponent(Component, opts) {
                 params: navParams
             };
 
-            if (oprions.enableScroll) {
+            if (options.enableScroll) {
                 historyState.scroll = {
                     x: window.scrollX || window.pageXOffset,
                     y: window.scrollY || window.pageYOffset
@@ -219,7 +219,7 @@ function createComponent(Component, opts) {
         componentWillUnmount: function () {
             this._history.off(this._onHistoryChange);
 
-            if (oprions.enableScroll) {
+            if (options.enableScroll) {
                 window.removeEventListener('scroll', this._onScroll);
             }
 
@@ -242,7 +242,7 @@ function createComponent(Component, opts) {
                         return;
                     }
                     historyState = {params: navParams, query: navQuery};
-                    if (oprions.enableScroll) {
+                    if (options.enableScroll) {
                         if (nav.preserveScrollPosition) {
                             historyState.scroll = {
                                 x: window.scrollX || window.pageXOffset,


### PR DESCRIPTION
Problem: https://github.com/yahoo/fluxible/issues/448
(SPA breaks in iOS safari after scrolling)

Solution: disable any scroll management in browser history if `enableScroll` is `false`.