### PR TITLE
[dispatchr] Defer rehydration of stores to when they are instantiated

### DIFF
--- a/packages/dispatchr/lib/DispatcherContext.js
+++ b/packages/dispatchr/lib/DispatcherContext.js
@@ -22,6 +22,7 @@ function DispatcherContext (dispatcher, context) {
         getStore: this.getStore.bind(this),
         waitFor: this.waitFor.bind(this)
     };
+    this.rehydratedStoreState = {};
 }
 
 /**
@@ -39,6 +40,13 @@ DispatcherContext.prototype.getStore = function getStore(name) {
             throw new Error('Store ' + storeName + ' was not registered.');
         }
         this.storeInstances[storeName] = new (this.dispatcher.stores[storeName])(this.dispatcherInterface);
+        if (this.rehydratedStoreState && this.rehydratedStoreState[storeName]) {
+            var state = this.rehydratedStoreState[storeName];
+            if (this.storeInstances[storeName].rehydrate) {
+                this.storeInstances[storeName].rehydrate(state);
+            }
+            this.rehydratedStoreState[storeName] = null;
+        }
     }
     return this.storeInstances[storeName];
 };
@@ -126,11 +134,7 @@ DispatcherContext.prototype.rehydrate = function rehydrate(dispatcherState) {
     var self = this;
     if (dispatcherState.stores) {
         Object.keys(dispatcherState.stores).forEach(function storeStateEach(storeName) {
-            var state = dispatcherState.stores[storeName],
-                store = self.getStore(storeName);
-            if (store.rehydrate) {
-                store.rehydrate(state);
-            }
+            self.rehydratedStoreState[storeName] = dispatcherState.stores[storeName];
         });
     }
 };

--- a/packages/dispatchr/tests/unit/lib/Dispatcher.js
+++ b/packages/dispatchr/tests/unit/lib/Dispatcher.js
@@ -234,13 +234,12 @@ describe('Dispatchr', function () {
         it('should rehydrate correctly', function () {
             dispatcherContext.rehydrate(expectedState);
 
-            expect(dispatcherContext.storeInstances).to.be.an('object');
-            expect(dispatcherContext.storeInstances.Store).to.be.an('object');
-            var mockStore = dispatcherContext.storeInstances.Store;
-            expect(mockStore.dispatcher).to.be.an('object');
-            expect(mockStore.dispatcher.getStore).to.be.a('function');
-            expect(mockStore.dispatcher.waitFor).to.be.a('function');
-            var state = mockStore.getState();
+            var store = dispatcherContext.getStore(mockStore);
+            expect(store).to.be.an('object');
+            expect(store.dispatcher).to.be.an('object');
+            expect(store.dispatcher.getStore).to.be.a('function');
+            expect(store.dispatcher.waitFor).to.be.a('function');
+            var state = store.getState();
             expect(state.called).to.equal(true);
             expect(state.page).to.equal('delay');
         });


### PR DESCRIPTION
This PR defers rehydration of stores until they are instantiated in `getStore()`. `getStore` is generally called from an action, dispatch, or from a view.  This could improve startup time for applications where stores are dehydrated but may not be immediately used for the initial render.

I changed the test to use the public interface for accessing the store rather than accessing the internal properties of dispatchr. The public interface has no breaking changes.