### PR TITLE
do not mutate global xhr path

### DIFF
--- a/packages/fluxible-plugin-fetchr/tests/unit/lib/fetchr-plugin.js
+++ b/packages/fluxible-plugin-fetchr/tests/unit/lib/fetchr-plugin.js
@@ -207,6 +207,21 @@ describe('fetchrPlugin', function () {
     });
 
     describe('plugContext', function () {
+        it('should allow xhrPath as option', function () {
+            mockReq = {
+                site: 'foo'
+            };
+            app = new FluxibleApp();
+            pluginInstance = fetchrPlugin({
+                xhrPath: 'custom2/api'
+            });
+            var contextPlug = pluginInstance.plugContext({
+                req: mockReq,
+                xhrContext: { device: 'tablet' }
+            });
+
+            expect(contextPlug.dehydrate().xhrPath).to.equal('custom2/api');
+        });
         it('should allow dynamic xhrPath', function () {
             mockReq = {
                 site: 'foo'


### PR DESCRIPTION
@lingyan @redonkulus @MattHo 

fix potential issue that if we are integrating `getXhrPath`, and generate different xhr path for each route, might cause some issue because we are always updating the global [xhrPath](https://github.com/yahoo/fluxible/pull/462/files#diff-b89bb231ea3f50b0af908412e103cc06R32) value. 
Which means we might serve xhrPath for previous route if somehow [Line 58](https://github.com/yahoo/fluxible/pull/462/files#diff-b89bb231ea3f50b0af908412e103cc06R58) is not executed or it's override by next request,  it's not clear but we got some issue on production if the traffic is getting heavier