### PR TITLE
store static routes

### DIFF
--- a/packages/fluxible-router/lib/RouteStore.js
+++ b/packages/fluxible-router/lib/RouteStore.js
@@ -158,6 +158,7 @@ RouteStore.withStaticRoutes = function (staticRoutes) {
     var staticRouter = new Router(staticRoutes);
     function StaticRouteStore() {
         RouteStore.apply(this, arguments);
+        this._routes = staticRoutes;
         this._router = staticRouter;
     }
     inherits(StaticRouteStore, RouteStore);

--- a/packages/fluxible-router/tests/unit/lib/RouteStore-test.js
+++ b/packages/fluxible-router/tests/unit/lib/RouteStore-test.js
@@ -4,7 +4,7 @@
  */
 var expect = require('chai').expect;
 var RouteStore = require('../../../').RouteStore;
-var StaticRouteStore = RouteStore.withStaticRoutes({
+var staticRoutes = {
     foo: {
         path: '/foo',
         method: 'get'
@@ -13,7 +13,8 @@ var StaticRouteStore = RouteStore.withStaticRoutes({
         path: '/bar',
         method: 'get'
     }
-});
+};
+var StaticRouteStore = RouteStore.withStaticRoutes(staticRoutes);
 
 describe('RouteStore', function () {
 
@@ -35,7 +36,7 @@ describe('RouteStore', function () {
                 expect(state.currentNavigate.transactionId).to.equal('first');
                 expect(state.currentNavigate.url).to.equal('/foo');
                 expect(state.currentNavigate.method).to.equal('get');
-                expect(state.routes).to.equal(null);
+                expect(state.routes).to.eql(staticRoutes);
             });
         });
         describe('rehydrate', function () {


### PR DESCRIPTION
@redonkulus @lingyan @mridgway 

not only store router, also store static routes.

so that when we use `RouteStore.withStaticRoutes` and get `RECEIVE_ROUTES`, we will merge them with static routes, 

now static routes will be removed once we `RECEIVE_ROUTES` and it's not dehydrated