### PR TITLE
update references to react version 15

### DIFF
--- a/docs/home.md
+++ b/docs/home.md
@@ -20,6 +20,6 @@ Helper utilities for integrating your Fluxible app into React [components](../pa
 
 Want to add your own interfaces to the Flux flow? [Plugins](../packages/fluxible/docs/api/Plugins.md) allow you to add methods to any of the contexts.
 
-## Updated for React 0.13
+## Updated for React 15
 
-Updated to follow React 0.13's changes and the deprecations coming in the next version of React.
+Updated to follow React 15's changes and the deprecations coming in the next version of React.

--- a/packages/fluxible/README.md
+++ b/packages/fluxible/README.md
@@ -31,7 +31,7 @@ Join the #fluxible channel of the [Reactiflux](http://reactiflux.com) Discord co
  * Higher order [components](https://github.com/yahoo/fluxible/blob/master/packages/fluxible/docs/api/Components.md) for easy integration
  * Enforcement of Flux flow - restricted access to the [Flux interface](https://github.com/yahoo/fluxible/blob/master/packages/fluxible/docs/api/FluxibleContext.md) from within components
  * [Pluggable](https://github.com/yahoo/fluxible/blob/master/packages/fluxible/docs/api/Plugins.md) - add your own interfaces to the Flux context
- * Updated for React 0.13
+ * Updated for React 15
 
 ## Extras
 

--- a/site/components/Home.js
+++ b/site/components/Home.js
@@ -74,8 +74,8 @@ class Home extends React.Component {
                     </div>
 
                     <div className="Bxz(bb) D(ib) Va(t) W(100%) Pstart(20px)--sm W(50%)--sm Bdt(1)--sm Mt(2em)--sm">
-                        <h2>Updated for React 0.15</h2>
-                        <p>Updated to follow React 0.15's changes and the deprecations coming in the next version of React.</p>
+                        <h2>Updated for React 15</h2>
+                        <p>Updated to follow React 15's changes and the deprecations coming in the next version of React.</p>
                     </div>
 
                     <p className="Ta(c) Mt(2em)--sm">


### PR DESCRIPTION
Hi,
I've noticed that some README files contain references to React 0.13 (or 0.15)
I've changed this to React 15.