### PR TITLE
Attempt to register stores that are not registered via getStore

### DIFF
--- a/packages/dispatchr/docs/dispatchr.md
+++ b/packages/dispatchr/docs/dispatchr.md
@@ -34,6 +34,8 @@ var MessageStore = require('./stores/MessageStore');
 dispatcher.getStore(MessageStore);
 ```
 
+_NOTE: This will attempt to lazily register the store if not registered at initializtion time._
+
 #### waitFor(storeClasses, callback)
 
 Waits for another store's handler to finish before calling the callback. This is useful from within stores if they need to wait for other stores to finish first.
@@ -48,4 +50,3 @@ Returns a serializable object containing the state of the dispatcher context as 
 #### rehydrate(dispatcherState)
 
 Takes an object representing the state of the dispatcher context (usually retrieved from dehydrate) to rehydrate the instance as well as the store instance state.
-

--- a/packages/dispatchr/lib/DispatcherContext.js
+++ b/packages/dispatchr/lib/DispatcherContext.js
@@ -37,7 +37,11 @@ DispatcherContext.prototype.getStore = function getStore(name) {
     if (!this.storeInstances[storeName]) {
         var Store = this.dispatcher.stores[storeName];
         if (!Store) {
-            throw new Error('Store ' + storeName + ' was not registered.');
+            if ('function' === typeof name) {
+                this.dispatcher.registerStore(name);
+            } else {
+                throw new Error('Store ' + storeName + ' was not registered.');
+            }
         }
         this.storeInstances[storeName] = new (this.dispatcher.stores[storeName])(this.dispatcherInterface);
         if (this.rehydratedStoreState && this.rehydratedStoreState[storeName]) {

--- a/packages/dispatchr/tests/unit/lib/Dispatcher.js
+++ b/packages/dispatchr/tests/unit/lib/Dispatcher.js
@@ -110,6 +110,19 @@ describe('Dispatchr', function () {
                 dispatcherContext.getStore('Invalid');
             }).to['throw'](Error);
         });
+        it('should register the store if not already registered with constructor is passed in', function () {
+            // create new dispatcher instance with no mockStore registered
+            var dispatcher = dispatchr.createDispatcher({
+                stores: [delayedStore, noDehydrateStore]
+            });
+
+            var dispatcherContext = dispatcher.createContext({}),
+                mockStoreInstance = dispatcherContext.getStore(mockStore);
+
+            expect(mockStoreInstance).to.be.an('object');
+
+            expect(dispatcherContext.getStore('Store')).to.equal(mockStoreInstance);
+        });
     });
 
     describe('#dispatch', function () {


### PR DESCRIPTION
@mridgway @lingyan 

This will try to register a store via `getStore` if the constructor is passed in. This helps in cases where all stores may not be registered at init time.