### PR TITLE
Allow error handler to be used instead of throwing

### DIFF
--- a/packages/dispatchr/docs/dispatchr.md
+++ b/packages/dispatchr/docs/dispatchr.md
@@ -3,6 +3,7 @@
 Dispatchr has one main function that is exported: `createDispatcher(options)`. This returns a new [`Dispatcher`](#dispatcher-api) instance. `createDispatcher` takes the following `options`:
 
  * `options.stores`: An array of stores to register automatically
+ * `options.errorHandler`: Optional function to [handle errors](#error-handling), throws errors if undefined
 
 ## Dispatcher API
 
@@ -49,3 +50,31 @@ Returns a serializable object containing the state of the dispatcher context as 
 
 Takes an object representing the state of the dispatcher context (usually retrieved from dehydrate) to rehydrate the instance as well as the store instance state.
 
+## Error handling
+
+By default Dispatcher will `throw` errors encountered (i.e. `registerStore`, `getStore`, etc). If you want to handle this more gracefully, you can pass in an `errorHandler` function when you call `createDispatcher`. The `errorHandler` function takes the following parameters:
+
+ * `info`: An object with the following properties:
+   * `message`: The error message
+   * `type`: The type of error (e.g. `STORE_UNREGISTERED`), defaults to `DISPATCHER_ERROR`
+   * `meta`: Additional information passed by Dispatchr
+ * `context`: An optional Dispatchr context object that provides access to any custom plugins
+
+ Example:
+
+```js
+var dispatcher = dispatchr.createDispatcher({
+    errorHandler: function (info, context) {
+        switch(info.type) {
+            // handle a specific error type differently
+            case 'STORE_UNREGISTERED':
+                if (context && context.beacon) {
+                    context.beacon.fire(info); // collect error information for later use
+                }
+            // throw by default
+            default:
+                throw new Error(info.message);
+        }
+    }
+});
+```

--- a/packages/dispatchr/lib/Dispatcher.js
+++ b/packages/dispatchr/lib/Dispatcher.js
@@ -11,6 +11,7 @@ var DispatcherContext = require('./DispatcherContext');
  * @class Dispatcher
  * @param {Object} options Dispatcher options
  * @param {Array} options.stores Array of stores to register
+ * @param {Function} options.errorHandler Called when an error occurrs. Allows user to handle/throw the error.
  * @constructor
  */
 function Dispatcher (options) {
@@ -19,6 +20,7 @@ function Dispatcher (options) {
     this.stores = {};
     this.handlers = {};
     this.handlers[DEFAULT] = [];
+    this.errorHandler = options.errorHandler;
     this.hasWarnedAboutNameProperty = false;
     options.stores.forEach(function (store) {
         this.registerStore(store);
@@ -52,7 +54,7 @@ Dispatcher.prototype.registerStore = function registerStore(store) {
             // Store is already registered, nothing to do
             return;
         }
-        throw new Error('Store with name `' + storeName + '` has already been registered. ' + 
+        throw new Error('Store with name `' + storeName + '` has already been registered. ' +
             'Make sure you do not have multiple copies of the store installed.');
     }
     this.stores[storeName] = store;

--- a/packages/dispatchr/lib/Dispatcher.js
+++ b/packages/dispatchr/lib/Dispatcher.js
@@ -156,11 +156,11 @@ Dispatcher.prototype._registerHandler = function registerHandler(action, name, h
  */
 Dispatcher.prototype._throwOrCallErrorHandler = function throwOrCallErrorHandler(message, type, context, meta) {
     if (this.errorHandler) {
-        this.errorHandler(context, {
+        this.errorHandler({
             message: message,
             type: type || 'DISPATCHER_ERROR',
             meta: meta
-        });
+        }, context);
     } else {
         throw new Error(message);
     }

--- a/packages/dispatchr/lib/Dispatcher.js
+++ b/packages/dispatchr/lib/Dispatcher.js
@@ -43,19 +43,22 @@ Dispatcher.prototype.createContext = function createContext(context) {
  */
 Dispatcher.prototype.registerStore = function registerStore(store) {
     if ('function' !== typeof store) {
-        throw new Error('registerStore requires a constructor as first parameter');
+        var message = 'registerStore requires a constructor as first parameter';
+        return this._throwOrCallErrorHandler(message, 'REGISTER_STORE_NO_CONSTRUCTOR');
     }
     var storeName = this.getStoreName(store);
     if (!storeName) {
-        throw new Error('Store is required to have a `storeName` property.');
+        var message = 'Store is required to have a `storeName` property.';
+        return this._throwOrCallErrorHandler(message, 'REGISTER_STORE_NO_STORENAME');
     }
     if (this.stores[storeName]) {
         if (this.stores[storeName] === store) {
             // Store is already registered, nothing to do
             return;
         }
-        throw new Error('Store with name `' + storeName + '` has already been registered. ' +
-            'Make sure you do not have multiple copies of the store installed.');
+        var message = 'Store with name `' + storeName + '` has already been registered. ' +
+            'Make sure you do not have multiple copies of the store installed.';
+        return this._throwOrCallErrorHandler(message, 'REGISTER_STORE_DUPLICATE_REGISTERED');
     }
     this.stores[storeName] = store;
     if (store.handlers) {
@@ -136,6 +139,31 @@ Dispatcher.prototype._registerHandler = function registerHandler(action, name, h
         handler: handler
     });
     return this.handlers.length - 1;
+};
+
+/**
+ * Executes `errorHandler` if registered, otherwise will throw an error
+ * @method _throwOrCallErrorHandler
+ * @private
+ * @static
+ * @param {String} message Error message to use for throw
+ * @param {String} [type=DISPATCHER_ERROR] Type of error generated
+ * @param {Object} [context] DispatcherContext object
+ * @param {Object} [meta] Additional information to pass to the error handler. Message
+    will automatically be passed into the meta object.
+ * @throws {Error} if `errorHandler` is not defined
+ * @returns {void}
+ */
+Dispatcher.prototype._throwOrCallErrorHandler = function throwOrCallErrorHandler(message, type, context, meta) {
+    if (this.errorHandler) {
+        this.errorHandler(context, {
+            message: message,
+            type: type || 'DISPATCHER_ERROR',
+            meta: meta
+        });
+    } else {
+        throw new Error(message);
+    }
 };
 
 module.exports = {

--- a/packages/dispatchr/lib/DispatcherContext.js
+++ b/packages/dispatchr/lib/DispatcherContext.js
@@ -37,7 +37,18 @@ DispatcherContext.prototype.getStore = function getStore(name) {
     if (!this.storeInstances[storeName]) {
         var Store = this.dispatcher.stores[storeName];
         if (!Store) {
-            throw new Error('Store ' + storeName + ' was not registered.');
+            var message = 'Store ' + storeName + ' was not registered.';
+            if (this.dispatcher.errorHandler) {
+                this.dispatcher.errorHandler(this.context, {
+                    type: 'STORE_UNREGISTERED',
+                    meta: {
+                        storeName: storeName,
+                        message: message
+                    }
+                });
+            } else {
+                throw new Error(message);
+            }
         }
         this.storeInstances[storeName] = new (this.dispatcher.stores[storeName])(this.dispatcherInterface);
         if (this.rehydratedStoreState && this.rehydratedStoreState[storeName]) {

--- a/packages/dispatchr/lib/DispatcherContext.js
+++ b/packages/dispatchr/lib/DispatcherContext.js
@@ -14,6 +14,7 @@ var debug = require('debug')('Dispatchr:DispatcherContext');
  * @constructor
  */
 function DispatcherContext (dispatcher, context) {
+    this.context = context;
     this.dispatcher = dispatcher;
     this.storeInstances = {};
     this.currentAction = null;

--- a/packages/dispatchr/lib/DispatcherContext.js
+++ b/packages/dispatchr/lib/DispatcherContext.js
@@ -39,17 +39,10 @@ DispatcherContext.prototype.getStore = function getStore(name) {
         var Store = this.dispatcher.stores[storeName];
         if (!Store) {
             var message = 'Store ' + storeName + ' was not registered.';
-            if (this.dispatcher.errorHandler) {
-                this.dispatcher.errorHandler(this.context, {
-                    type: 'STORE_UNREGISTERED',
-                    meta: {
-                        storeName: storeName,
-                        message: message
-                    }
-                });
-            } else {
-                throw new Error(message);
-            }
+            var meta = {
+                storeName: storeName
+            };
+            return this.dispatcher._throwOrCallErrorHandler(message, 'STORE_UNREGISTERED', this.context, meta);
         }
         this.storeInstances[storeName] = new (this.dispatcher.stores[storeName])(this.dispatcherInterface);
         if (this.rehydratedStoreState && this.rehydratedStoreState[storeName]) {
@@ -72,10 +65,16 @@ DispatcherContext.prototype.getStore = function getStore(name) {
  */
 DispatcherContext.prototype.dispatch = function dispatch(actionName, payload) {
     if (!actionName) {
-        throw new Error('actionName parameter `' + actionName + '` is invalid.');
+        var message = 'actionName parameter `' + actionName + '` is invalid.';
+        return this.dispatcher._throwOrCallErrorHandler(message, 'DISPATCH_INVALID_ACTIONNAME', this.context);
     }
     if (this.currentAction) {
-        throw new Error('Cannot call dispatch while another dispatch is executing. Attempted to execute \'' + actionName + '\' but \'' + this.currentAction.name + '\' is already executing.');
+        var message = 'Cannot call dispatch while another dispatch is executing. Attempted to execute \'' + actionName + '\' but \'' + this.currentAction.name + '\' is already executing.';
+        var meta = {
+            actionName: actionName,
+            payload: payload
+        };
+        return this.dispatcher._throwOrCallErrorHandler(message, 'DISPATCH_EXECUTING', this.context, meta);
     }
     var actionHandlers = this.dispatcher.handlers[actionName] || [],
         defaultHandlers = this.dispatcher.handlers[DEFAULT] || [];
@@ -100,7 +99,11 @@ DispatcherContext.prototype.dispatch = function dispatch(actionName, payload) {
                 handlerFns[store.name] = store.handler.bind(storeInstance);
             } else {
                 if (!storeInstance[store.handler]) {
-                    throw new Error(store.name + ' does not have a method called ' + store.handler);
+                    var message = store.name + ' does not have a method called ' + store.handler;
+                    var meta = {
+                        store: store
+                    };
+                    return this.dispatcher._throwOrCallErrorHandler(message, 'DISPATCH_INVALID_STORE_METHOD', this.context, meta);
                 }
                 handlerFns[store.name] = storeInstance[store.handler].bind(storeInstance);
             }
@@ -161,7 +164,11 @@ DispatcherContext.prototype.rehydrate = function rehydrate(dispatcherState) {
  */
 DispatcherContext.prototype.waitFor = function waitFor(stores, callback) {
     if (!this.currentAction) {
-        throw new Error('waitFor called even though there is no action dispatching');
+        var message = 'waitFor called even though there is no action dispatching';
+        var meta = {
+            stores: stores
+        };
+        return this.dispatcher._throwOrCallErrorHandler(message, 'WAITFOR_NO_ACTION', this.context, meta);
     }
     this.currentAction.waitFor(stores, callback);
 };

--- a/packages/dispatchr/tests/unit/lib/Dispatcher.js
+++ b/packages/dispatchr/tests/unit/lib/Dispatcher.js
@@ -256,4 +256,50 @@ describe('Dispatchr', function () {
         });
     });
 
+    describe('#errorHandler', function () {
+        it('should handle errors when passed in', function (done) {
+            var dispatcher = dispatchr.createDispatcher({
+                errorHandler: function (context, info) {
+                    expect(info).to.be.an('object');
+                    expect(info.type).equal('REGISTER_STORE_NO_CONSTRUCTOR');
+                    expect(info.message).equal('registerStore requires a constructor as first parameter');
+                    done();
+                }
+            });
+            dispatcher.registerStore('DoesNotExist');
+        });
+
+        it('should throw an error', function () {
+            var dispatcher = dispatchr.createDispatcher({
+                errorHandler: function (context, info) {
+                    throw new Error(info.message);
+                }
+            });
+            expect(function () {
+                dispatcher.registerStore('DoesNotExist');
+            }).to['throw'](Error);
+        });
+
+        it('should expose context and handle additional meta data', function (done) {
+            var NewStore = function Store () {};
+            NewStore.storeName = 'NewStore';
+
+            var dispatcher = dispatchr.createDispatcher({
+                    errorHandler: function (context, info) {
+                        expect(context).to.be.an('object');
+                        expect(context.test).equal('test');
+                        expect(info).to.be.an('object');
+                        expect(info.type).equal('STORE_UNREGISTERED');
+                        expect(info.message).equal('Store NewStore was not registered.');
+                        expect(info.meta.storeName).equal('NewStore');
+                        done();
+                    }
+                }),
+                context = {test: 'test'},
+                dispatcherContext = dispatcher.createContext(context);
+
+            dispatcherContext.getStore(NewStore);
+        });
+    });
+
 });

--- a/packages/dispatchr/tests/unit/lib/Dispatcher.js
+++ b/packages/dispatchr/tests/unit/lib/Dispatcher.js
@@ -259,7 +259,7 @@ describe('Dispatchr', function () {
     describe('#errorHandler', function () {
         it('should handle errors when passed in', function (done) {
             var dispatcher = dispatchr.createDispatcher({
-                errorHandler: function (context, info) {
+                errorHandler: function (info, context) {
                     expect(info).to.be.an('object');
                     expect(info.type).equal('REGISTER_STORE_NO_CONSTRUCTOR');
                     expect(info.message).equal('registerStore requires a constructor as first parameter');
@@ -271,7 +271,7 @@ describe('Dispatchr', function () {
 
         it('should throw an error', function () {
             var dispatcher = dispatchr.createDispatcher({
-                errorHandler: function (context, info) {
+                errorHandler: function (info, context) {
                     throw new Error(info.message);
                 }
             });
@@ -285,7 +285,7 @@ describe('Dispatchr', function () {
             NewStore.storeName = 'NewStore';
 
             var dispatcher = dispatchr.createDispatcher({
-                    errorHandler: function (context, info) {
+                    errorHandler: function (info, context) {
                         expect(context).to.be.an('object');
                         expect(context.test).equal('test');
                         expect(info).to.be.an('object');


### PR DESCRIPTION
@mridgway @lingyan @kaesonho 

Opening this up for discussion. 

We have the use case where we want to beacon back to the server when a store registration fails. We can't do this today because dispatchr [throws](https://github.com/yahoo/fluxible/blob/master/packages/dispatchr/lib/DispatcherContext.js#L40) with no way of handling it. In this PR, I've introduced a function handler that can be passed in so that applications can do something with the error (eventually throwing themselves).

Additionally, I've tried to make the error handler sane by passing in `type` and `meta` information arguments so applications can handle various errors differently.

This would remove the need for https://github.com/yahoo/fluxible/pull/492