### PR TITLE
Updating connectToStores to account for React Transition Group methods

### DIFF
--- a/packages/fluxible-addons-react/connectToStores.js
+++ b/packages/fluxible-addons-react/connectToStores.js
@@ -43,6 +43,12 @@ function createComponent(Component, stores, getStateFromStores, customContextTyp
         componentWillReceiveProps: function componentWillReceiveProps(nextProps){
             this.setState(this.getStateFromStores(nextProps));
         },
+        componentWillEnter: Component.prototype.componentWillEnter,
+        componentDidEnter: Component.prototype.componentDidEnter,
+        componentWillAppear: Component.prototype.componentWillAppear,
+        componentDidAppear: Component.prototype.componentDidAppear,
+        componentWillLeave: Component.prototype.componentWillLeave,
+        componentDidLeave: Component.prototype.componentDidLeave,
         getStateFromStores: function (props) {
             props = props || this.props;
             return getStateFromStores(this.context, props);


### PR DESCRIPTION
When you have a child of React Transition Group that is wrapped in the connectToStores higher order component the Transition Group lifecycle methods (https://facebook.github.io/react/docs/animation.html#low-level-api-reacttransitiongroup) will be stripped from the component. The fix for this is to account for the Transition Group lifecycle methods in connectToStores.