### PR TITLE
Allow custom props to be added to filtered ones

### DIFF
--- a/packages/fluxible-router/lib/createNavLinkComponent.js
+++ b/packages/fluxible-router/lib/createNavLinkComponent.js
@@ -141,6 +141,15 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
         getDefaultChildProps: function () {
             return {};
         },
+        /**
+         * Allows consumer to add additional properties to filter from the node
+         * @see https://fb.me/react-unknown-prop
+         * @method getFilteredProps
+         * @returns {Array} filteredProps
+         */
+        getFilteredProps: function () {
+            return [];
+        },
         getNavParams: function (props) {
             return props.navParams;
         },
@@ -251,7 +260,7 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
                 'routeName',
                 'stopPropagation',
                 'validate'
-            ]);
+            ].concat(this.getFilteredProps()));
 
             if (this.state.isActive) {
                 if (this.state.activeElement) {


### PR DESCRIPTION
@kaesonho @lingyan @mridgway 

This basically allows consumers to [pass in additional properties](https://github.com/yahoo/fluxible/blob/master/packages/fluxible-router/lib/createNavLinkComponent.js#L291) to be filtered before the render call. The consumer will return an array from `getFilteredProps` like so:

```js
createNavLinkComponent({
    // ...
    getFilteredProps: function () {
        return [
            'bindClickEvent',
            'follow',
            'i13nModel',
            'isLeafNode',
            'model',
            'scanLinks'
        ];
    },
    // ...
});
```

Once approved I will add this to the 1.x branch.