### PR TITLE
add "homepage" field for "npm home" cli

### DIFF
--- a/packages/fluxible/package.json
+++ b/packages/fluxible/package.json
@@ -26,6 +26,7 @@
       "url": "https://github.com/yahoo/fluxible/blob/master/LICENSE.md"
     }
   ],
+  "homepage": "http://fluxible.io/",
   "keywords": [
     "yahoo",
     "flux",

--- a/packages/fluxible/package.json
+++ b/packages/fluxible/package.json
@@ -26,7 +26,7 @@
       "url": "https://github.com/yahoo/fluxible/blob/master/LICENSE.md"
     }
   ],
-  "homepage": "http://fluxible.io/",
+  "homepage": "https://fluxible.io/",
   "keywords": [
     "yahoo",
     "flux",


### PR DESCRIPTION
@mridgway @redonkulus 

`npm home fluxible` and `npm docs fluxible` will open fluxible.io site in browser with this change :)