### PR TITLE
For invalid href and route name, only throw error in development env,…

### DIFF
--- a/packages/fluxible-router/lib/createNavLinkComponent.js
+++ b/packages/fluxible-router/lib/createNavLinkComponent.js
@@ -1,13 +1,14 @@
 /**
- * Copyright 2015, Yahoo! Inc.
+ * Copyright 2015-Present, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
-/*global window */
+/*global window,process */
 'use strict';
 var React = require('react');
 var RouteStore = require('./RouteStore');
 var debug = require('debug')('NavLink');
 var navigateAction = require('./navigateAction');
+var __DEV__ = process.env.NODE_ENV !== 'production';
 
 function objectWithoutProperties(obj, keys) {
     var target = {};
@@ -152,11 +153,6 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             if (!href && routeName) {
                 href = routeStore.makePath(routeName, navParams, queryParams);
             }
-            if (!href) {
-                throw new Error('NavLink created without href or unresolvable ' +
-                    'routeName \'' + routeName + '\' with params ' +
-                    JSON.stringify(navParams));
-            }
             return href;
         },
         /**
@@ -292,12 +288,23 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             this.dispatchNavAction(e);
         },
         render: function () {
-            var href = this._getHrefFromProps(this.props);
-            var activeClass = this.props.activeClass;
-            var activeStyle = this.props.activeStyle;
-            var activeElement = this.props.activeElement;
+            var props = this.props;
+            var href = this._getHrefFromProps(props);
+            if (!href) {
+                if (__DEV__) {
+                    throw new Error('NavLink created with invalid href \'' + props.href +
+                        '\'or unresolvable routeName \'' + props.routeName);
+                } else {
+                    console.error('Error: Invalid NavLink, skip rendering...', props);
+                    return null;
+                }
+            }
 
-            var childProps = objectWithoutProperties(this.props, [
+            var activeClass = props.activeClass;
+            var activeStyle = props.activeStyle;
+            var activeElement = props.activeElement;
+
+            var childProps = objectWithoutProperties(props, [
                 'activeClass',
                 'activeElement',
                 'activeStyle',
@@ -318,21 +325,21 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
                 isActive = routeStore.isActive(href);
             }
 
-            var style = this.props.style;
-            var className = this.props.className;
+            var style = props.style;
+            var className = props.className;
             if (isActive) {
                 if (activeClass) {
                     className = className ? (className + ' ') : '';
                     className += activeClass;
                 }
                 if (activeStyle) {
-                    style = Object.assign({}, this.props.style, activeStyle);
+                    style = Object.assign({}, props.style, activeStyle);
                 }
             }
 
             var defaultProps = this.getDefaultChildProps();
 
-            if (!(isActive && activeElement) && !this.props.onClick) {
+            if (!(isActive && activeElement) && !props.onClick) {
                 childProps.onClick = this.clickHandler.bind(this);
             }
 
@@ -350,7 +357,7 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             return React.createElement(
                 childElement,
                 childProps,
-                this.props.children
+                props.children
             );
         }
     }, overwriteSpec));

--- a/packages/fluxible-router/lib/createNavLinkComponent.js
+++ b/packages/fluxible-router/lib/createNavLinkComponent.js
@@ -48,7 +48,7 @@ function getRelativeHref(href) {
         throw new Error('getRelativeHref() only supported on client side');
     }
 
-    if (href[0] === '/' || href[0] === '#') {
+    if (!href || href[0] === '/' || href[0] === '#') {
         return href;
     }
 
@@ -293,12 +293,11 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             var href = this._getHrefFromProps(props);
             if (!href) {
                 if (__DEV__) {
-                    throw new Error('NavLink created with invalid href \'' + props.href +
+                    throw new Error('NavLink created with empty or missing href \'' + props.href +
                         '\'or unresolvable routeName \'' + props.routeName);
                 } else {
                     var logError = (this.context.logger && this.context.logger.error) || console.error;
-                    logError('Error: Invalid NavLink, skip rendering...', props);
-                    return null;
+                    logError('Error: Render NavLink with empty or missing href', props);
                 }
             }
 

--- a/packages/fluxible-router/lib/createNavLinkComponent.js
+++ b/packages/fluxible-router/lib/createNavLinkComponent.js
@@ -72,7 +72,8 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
         displayName: 'NavLink',
         contextTypes: {
             executeAction: React.PropTypes.func.isRequired,
-            getStore: React.PropTypes.func.isRequired
+            getStore: React.PropTypes.func.isRequired,
+            logger: React.PropTypes.object
         },
         propTypes: {
             href: React.PropTypes.string,
@@ -295,7 +296,8 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
                     throw new Error('NavLink created with invalid href \'' + props.href +
                         '\'or unresolvable routeName \'' + props.routeName);
                 } else {
-                    console.error('Error: Invalid NavLink, skip rendering...', props);
+                    var logError = (this.context.logger && this.context.logger.error) || console.error;
+                    logError('Error: Invalid NavLink, skip rendering...', props);
                     return null;
                 }
             }

--- a/packages/fluxible-router/tests/mocks/MockAppComponent.js
+++ b/packages/fluxible-router/tests/mocks/MockAppComponent.js
@@ -21,10 +21,13 @@ var MockAppComponent = React.createClass({
     }
 });
 
+var customContextTypes = {
+    logger: React.PropTypes.object
+};
 module.exports = provideContext(handleHistory(MockAppComponent, {
     checkRouteOnPageLoad: false,
     enableScroll: true
-}));
+}), customContextTypes);
 
 module.exports.createWrappedMockAppComponent = function createWrappedMockAppComponent(opts) {
     return provideContext(handleHistory(MockAppComponent, opts));

--- a/packages/fluxible-router/tests/unit/lib/NavLink-test.js
+++ b/packages/fluxible-router/tests/unit/lib/NavLink-test.js
@@ -662,23 +662,46 @@ describe('NavLink NODE_ENV === development', function () {
 
 describe('NavLink NODE_ENV === production', function () {
     var mockContext;
+    var loggerError;
+    var logger = {
+        error: function () {
+            loggerError = arguments;
+        }
+    };
 
     beforeEach(function (done) {
+        loggerError = null;
         setup({nodeEnv: 'production'}, function (err, context) {
             mockContext = context;
+            mockContext.logger = logger;
             done(err);
         });
     });
     afterEach(tearDown);
-    it('should render null if href and routeName undefined', function () {
-        var navParams = {};
-        var div = document.createElement('div');
-        ReactDOM.render(
+    it('should render link with missing href with console error', function () {
+        var link = ReactTestUtils.renderIntoDocument(
             <MockAppComponent context={mockContext}>
-                <NavLink navParams={navParams} />
-            </MockAppComponent>,
-            div
+                <NavLink>
+                    bar
+                </NavLink>
+            </MockAppComponent>
         );
-        expect(div.innerHTML).to.equal('<!-- react-empty: 1 -->');
+        var linkNode = ReactDOM.findDOMNode(link);
+        expect(linkNode.getAttribute('href')).to.equal(null, linkNode.outerHTML);
+        expect(linkNode.textContent).to.equal('bar', linkNode.outerHTML);
+        expect(loggerError[0]).to.contain('Error: Render NavLink with empty or missing href');
+    });
+    it('should render link with empty href with console error', function () {
+        var link = ReactTestUtils.renderIntoDocument(
+            <MockAppComponent context={mockContext}>
+                <NavLink href=''>
+                    bar
+                </NavLink>
+            </MockAppComponent>
+        );
+        var linkNode = ReactDOM.findDOMNode(link);
+        expect(linkNode.getAttribute('href')).to.equal('', linkNode.outerHTML);
+        expect(linkNode.textContent).to.equal('bar', linkNode.outerHTML);
+        expect(loggerError[0]).to.contain('Error: Render NavLink with empty or missing href');
     });
 });

--- a/packages/fluxible-router/tests/unit/lib/NavLink-test.js
+++ b/packages/fluxible-router/tests/unit/lib/NavLink-test.js
@@ -3,19 +3,23 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 /*globals describe,it,before,beforeEach */
+
+var jsdom = require('jsdom');
+var expect = require('chai').expect;
+var fs = require('fs');
+var resolve = require('resolve');
+var createMockComponentContext = require('fluxible/utils/createMockComponentContext');
+var navigateAction = require('../../../').navigateAction;
+var RouteStore = require('../../../').RouteStore;
+var ORIG_NODE_ENV = process.env.NODE_ENV;
+
 var React;
 var ReactDOM;
 var NavLink;
 var createNavLinkComponent;
 var ReactTestUtils;
-var jsdom = require('jsdom');
-var expect = require('chai').expect;
-var onClickMock;
 var testResult;
 var MockAppComponent;
-var RouteStore = require('../../../').RouteStore;
-var createMockComponentContext = require('fluxible/utils/createMockComponentContext');
-var navigateAction = require('../../../').navigateAction;
 
 var TestRouteStore = RouteStore.withStaticRoutes({
     foo: { path: '/foo', method: 'get' },
@@ -25,50 +29,68 @@ var TestRouteStore = RouteStore.withStaticRoutes({
     fooAB: { path: '/foo/:a/:b', method: 'get' }
 });
 
-onClickMock = function () {
+function onClickMock() {
     testResult.onClickMockInvoked = true;
-};
+}
+
+function setup(options, done) {
+    if (options.nodeEnv) {
+        process.env.NODE_ENV = options.nodeEnv;
+    }
+    var path = fs.realpathSync(resolve.sync('../../../lib/createNavLinkComponent'));
+    delete require.cache[path];
+    path = fs.realpathSync(resolve.sync('../../../lib/NavLink'));
+    delete require.cache[path];
+
+    jsdom.env({
+        url: 'http://yahoo.com',
+        html: '<html><body></body></html>',
+        done: function (err, window) {
+            if (err) {
+                done(err);
+                return;
+            }
+            global.document = window.document;
+            global.window = window;
+            global.navigator = window.navigator;
+
+            React = require('react');
+            ReactDOM = require('react-dom');
+            ReactTestUtils = require('react-addons-test-utils');
+            var mockContext = createMockComponentContext({
+                stores: [TestRouteStore]
+            });
+            mockContext.getStore('RouteStore')._handleNavigateStart({
+                url: '/foo',
+                method: 'GET'
+            });
+            MockAppComponent = require('../../mocks/MockAppComponent');
+            NavLink = require('../../../lib/NavLink');
+            createNavLinkComponent = require('../../../lib/createNavLinkComponent');
+            testResult = {};
+            done(null, mockContext);
+        }
+    });
+}
+
+function tearDown() {
+    delete global.window;
+    delete global.document;
+    delete global.navigator;
+    process.env.NODE_ENV = ORIG_NODE_ENV;
+}
 
 describe('NavLink', function () {
     var mockContext;
 
     beforeEach(function (done) {
-        jsdom.env({
-            url: 'http://yahoo.com',
-            html: '<html><body></body></html>',
-            done: function (err, window) {
-                if (err) {
-                    done(err);
-                    return;
-                }
-                global.document = window.document;
-                global.window = window;
-                global.navigator = window.navigator;
-
-                React = require('react');
-                ReactDOM = require('react-dom');
-                ReactTestUtils = require('react-addons-test-utils');
-                mockContext = createMockComponentContext({
-                    stores: [TestRouteStore]
-                });
-                mockContext.getStore('RouteStore')._handleNavigateStart({
-                    url: '/foo',
-                    method: 'GET'
-                });
-                MockAppComponent = require('../../mocks/MockAppComponent');
-                NavLink = require('../../../lib/NavLink');
-                createNavLinkComponent = require('../../../lib/createNavLinkComponent');
-                testResult = {};
-                done();
-            }
+        setup({}, function (err, context) {
+            mockContext = context;
+            done(err);
         });
     });
 
-    afterEach(function () {
-        delete global.window;
-        delete global.document;
-        delete global.navigator;
-    });
+    afterEach(tearDown);
 
     describe('render()', function () {
         it('should set href correctly', function () {
@@ -111,16 +133,6 @@ describe('NavLink', function () {
             expect(ReactDOM.findDOMNode(link).getAttribute('href')).to.equal('/internal');
         });
 
-        it('should throw if href and routeName undefined', function () {
-            var navParams = {a: 1, b: 2};
-            expect(function () {
-                ReactTestUtils.renderIntoDocument(
-                    <MockAppComponent context={mockContext}>
-                        <NavLink navParams={navParams} />
-                    </MockAppComponent>
-                );
-            }).to['throw']();
-        });
         it('should create href with query params', function () {
             var queryParams = {a: 1, b: 2};
             var link = ReactTestUtils.renderIntoDocument(
@@ -130,6 +142,7 @@ describe('NavLink', function () {
             );
             expect(ReactDOM.findDOMNode(link).getAttribute('href')).to.equal('/foo?a=1&b=2');
         });
+
         it('should set style and className properties', function () {
             var link = ReactTestUtils.renderIntoDocument(
                 <MockAppComponent context={mockContext}>
@@ -141,6 +154,7 @@ describe('NavLink', function () {
             expect(ReactDOM.findDOMNode(link).getAttribute('class')).to.equal('foo');
             expect(ReactDOM.findDOMNode(link).getAttribute('style')).to.contain('background-color');
         });
+
         it('should set active state if href matches current route', function () {
             var navParams = {a: 1, b: 2};
             var link = ReactTestUtils.renderIntoDocument(
@@ -622,5 +636,49 @@ describe('NavLink', function () {
             ReactDOM.unmountComponentAtNode(div);
             expect(routeStore.listeners('change').length).to.equal(0);
         });
+    });
+});
+
+describe('NavLink NODE_ENV === development', function () {
+    var mockContext;
+    beforeEach(function (done) {
+        setup({nodeEnv: 'development'}, function (err, context) {
+            mockContext = context;
+            done(err);
+        });
+    });
+    afterEach(tearDown);
+    it('should throw if href and routeName undefined', function () {
+        var navParams = {};
+        expect(function () {
+            ReactTestUtils.renderIntoDocument(
+                <MockAppComponent context={mockContext}>
+                    <NavLink navParams={navParams} />
+                </MockAppComponent>
+            );
+        }).to['throw']();
+    });
+});
+
+describe('NavLink NODE_ENV === production', function () {
+    var mockContext;
+
+    beforeEach(function (done) {
+        setup({nodeEnv: 'production'}, function (err, context) {
+            mockContext = context;
+            done(err);
+        });
+    });
+    afterEach(tearDown);
+    it('should render null if href and routeName undefined', function () {
+        var navParams = {};
+        var div = document.createElement('div');
+        ReactDOM.render(
+            <MockAppComponent context={mockContext}>
+                <NavLink navParams={navParams} />
+            </MockAppComponent>,
+            div
+        );
+        expect(div.innerHTML).to.equal('<!-- react-empty: 1 -->');
     });
 });


### PR DESCRIPTION
… render with empty href in prod with console error

Avoid crashing node process/ui thread in production just because one NavLink is configured wrong.

Will backport to 0.4.x after this PR is reviewed.

@kaesonho @mridgway @redonkulus 