### PR TITLE
For invalid href and route name, only throw error in development env,…

### DIFF
--- a/packages/fluxible-router/tests/mocks/MockAppComponent.js
+++ b/packages/fluxible-router/tests/mocks/MockAppComponent.js
@@ -21,10 +21,14 @@ var MockAppComponent = React.createClass({
     }
 });
 
+var customContextTypes = {
+    logger: React.PropTypes.object
+};
+
 module.exports = provideContext(handleHistory(MockAppComponent, {
     checkRouteOnPageLoad: false,
     enableScroll: true
-}));
+}), customContextTypes);
 
 module.exports.createWrappedMockAppComponent = function createWrappedMockAppComponent(opts) {
     return provideContext(handleHistory(MockAppComponent, opts));

--- a/packages/fluxible-router/tests/unit/lib/NavLink-test.js
+++ b/packages/fluxible-router/tests/unit/lib/NavLink-test.js
@@ -3,19 +3,22 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 /*globals describe,it,before,beforeEach */
+var jsdom = require('jsdom');
+var expect = require('chai').expect;
+var fs = require('fs');
+var resolve = require('resolve');
+var createMockComponentContext = require('fluxible/utils/createMockComponentContext');
+var navigateAction = require('../../../').navigateAction;
+var RouteStore = require('../../../').RouteStore;
+var ORIG_NODE_ENV = process.env.NODE_ENV;
+
 var React;
 var ReactDOM;
 var NavLink;
 var createNavLinkComponent;
 var ReactTestUtils;
-var jsdom = require('jsdom');
-var expect = require('chai').expect;
-var onClickMock;
 var testResult;
 var MockAppComponent;
-var RouteStore = require('../../../').RouteStore;
-var createMockComponentContext = require('fluxible/utils/createMockComponentContext');
-var navigateAction = require('../../../').navigateAction;
 
 var TestRouteStore = RouteStore.withStaticRoutes({
     foo: { path: '/foo', method: 'get' },
@@ -25,50 +28,68 @@ var TestRouteStore = RouteStore.withStaticRoutes({
     fooAB: { path: '/foo/:a/:b', method: 'get' }
 });
 
-onClickMock = function () {
+function onClickMock() {
     testResult.onClickMockInvoked = true;
-};
+}
+
+function setup(options, done) {
+    if (options.nodeEnv) {
+        process.env.NODE_ENV = options.nodeEnv;
+    }
+    var path = fs.realpathSync(resolve.sync('../../../lib/createNavLinkComponent'));
+    delete require.cache[path];
+    path = fs.realpathSync(resolve.sync('../../../lib/NavLink'));
+    delete require.cache[path];
+
+    jsdom.env({
+        url: 'http://yahoo.com',
+        html: '<html><body></body></html>',
+        done: function (err, window) {
+            if (err) {
+                done(err);
+                return;
+            }
+            global.document = window.document;
+            global.window = window;
+            global.navigator = window.navigator;
+
+            React = require('react');
+            ReactDOM = require('react-dom');
+            ReactTestUtils = require('react-addons-test-utils');
+            var mockContext = createMockComponentContext({
+                stores: [TestRouteStore]
+            });
+            mockContext.getStore('RouteStore')._handleNavigateStart({
+                url: '/foo',
+                method: 'GET'
+            });
+            MockAppComponent = require('../../mocks/MockAppComponent');
+            NavLink = require('../../../lib/NavLink');
+            createNavLinkComponent = require('../../../lib/createNavLinkComponent');
+            testResult = {};
+            done(null, mockContext);
+        }
+    });
+}
+
+function tearDown() {
+    delete global.window;
+    delete global.document;
+    delete global.navigator;
+    process.env.NODE_ENV = ORIG_NODE_ENV;
+}
 
 describe('NavLink', function () {
     var mockContext;
 
     beforeEach(function (done) {
-        jsdom.env({
-            url: 'http://yahoo.com',
-            html: '<html><body></body></html>',
-            done: function (err, window) {
-                if (err) {
-                    done(err);
-                    return;
-                }
-                global.document = window.document;
-                global.window = window;
-                global.navigator = window.navigator;
-
-                React = require('react');
-                ReactDOM = require('react-dom');
-                ReactTestUtils = require('react-addons-test-utils');
-                mockContext = createMockComponentContext({
-                    stores: [TestRouteStore]
-                });
-                mockContext.getStore('RouteStore')._handleNavigateStart({
-                    url: '/foo',
-                    method: 'GET'
-                });
-                MockAppComponent = require('../../mocks/MockAppComponent');
-                NavLink = require('../../../lib/NavLink');
-                createNavLinkComponent = require('../../../lib/createNavLinkComponent');
-                testResult = {};
-                done();
-            }
+        setup({}, function (err, context) {
+            mockContext = context;
+            done(err);
         });
     });
 
-    afterEach(function () {
-        delete global.window;
-        delete global.document;
-        delete global.navigator;
-    });
+    afterEach(tearDown);
 
     describe('render()', function () {
         it('should set href correctly', function () {
@@ -109,17 +130,6 @@ describe('NavLink', function () {
                 </MockAppComponent>
             );
             expect(ReactDOM.findDOMNode(link).getAttribute('href')).to.equal('/internal');
-        });
-
-        it('should throw if href and routeName undefined', function () {
-            var navParams = {a: 1, b: 2};
-            expect(function () {
-                ReactTestUtils.renderIntoDocument(
-                    <MockAppComponent context={mockContext}>
-                        <NavLink navParams={navParams} />
-                    </MockAppComponent>
-                );
-            }).to['throw']();
         });
 
         it('should set active state if href matches current route', function () {
@@ -588,5 +598,72 @@ describe('NavLink', function () {
             ReactDOM.unmountComponentAtNode(div);
             expect(routeStore.listeners('change').length).to.equal(0);
         });
+    });
+});
+
+describe('NavLink NODE_ENV === development', function () {
+    var mockContext;
+    beforeEach(function (done) {
+        setup({nodeEnv: 'development'}, function (err, context) {
+            mockContext = context;
+            done(err);
+        });
+    });
+    afterEach(tearDown);
+    it('should throw if href and routeName undefined', function () {
+        var navParams = {};
+        expect(function () {
+            ReactTestUtils.renderIntoDocument(
+                <MockAppComponent context={mockContext}>
+                    <NavLink navParams={navParams} />
+                </MockAppComponent>
+            );
+        }).to['throw']();
+    });
+});
+
+describe('NavLink NODE_ENV === production', function () {
+    var mockContext;
+    var loggerError;
+    var logger = {
+        error: function () {
+            loggerError = arguments;
+        }
+    };
+
+    beforeEach(function (done) {
+        loggerError = null;
+        setup({nodeEnv: 'production'}, function (err, context) {
+            mockContext = context;
+            mockContext.logger = logger;
+            done(err);
+        });
+    });
+    afterEach(tearDown);
+    it('should render link with missing href with console error', function () {
+        var link = ReactTestUtils.renderIntoDocument(
+            <MockAppComponent context={mockContext}>
+                <NavLink>
+                    bar
+                </NavLink>
+            </MockAppComponent>
+        );
+        var linkNode = ReactDOM.findDOMNode(link);
+        expect(linkNode.getAttribute('href')).to.equal(null, linkNode.outerHTML);
+        expect(linkNode.textContent).to.equal('bar', linkNode.outerHTML);
+        expect(loggerError[0]).to.contain('Error: Render NavLink with empty or missing href');
+    });
+    it('should render link with empty href with console error', function () {
+        var link = ReactTestUtils.renderIntoDocument(
+            <MockAppComponent context={mockContext}>
+                <NavLink href=''>
+                    bar
+                </NavLink>
+            </MockAppComponent>
+        );
+        var linkNode = ReactDOM.findDOMNode(link);
+        expect(linkNode.getAttribute('href')).to.equal('', linkNode.outerHTML);
+        expect(linkNode.textContent).to.equal('bar', linkNode.outerHTML);
+        expect(loggerError[0]).to.contain('Error: Render NavLink with empty or missing href');
     });
 });


### PR DESCRIPTION
… render with empty href in prod with console error

backport the fix from https://github.com/yahoo/fluxible/pull/505

@kaesonho @redonkulus @mridgway 