### PR TITLE
Expose WrappedComponent from StoreConnector

### DIFF
--- a/packages/fluxible-addons-react/connectToStores.js
+++ b/packages/fluxible-addons-react/connectToStores.js
@@ -59,6 +59,7 @@ function createComponent(Component, stores, getStateFromStores, customContextTyp
     });
 
     hoistNonReactStatics(StoreConnector, Component);
+    StoreConnector.WrappedComponent = Component;
 
     return StoreConnector;
 }

--- a/packages/fluxible-router/lib/handleHistory.js
+++ b/packages/fluxible-router/lib/handleHistory.js
@@ -286,7 +286,7 @@ function createComponent(Component, opts) {
     // Copy statics to HistoryHandler
     hoistNonReactStatics(HistoryHandler, Component);
 
-    HistoryHandler.wrappedComponent = Component;
+    HistoryHandler.wrappedComponent = HistoryHandler.WrappedComponent = Component;
 
     return handleRoute(HistoryHandler);
 }

--- a/packages/fluxible-router/lib/handleRoute.js
+++ b/packages/fluxible-router/lib/handleRoute.js
@@ -52,7 +52,7 @@ function createComponent(Component) {
     // Copy statics to RouteHandler
     hoistNonReactStatics(RouteHandler, Component);
 
-    RouteHandler.wrappedComponent = Component;
+    RouteHandler.wrappedComponent = RouteHandler.WrappedComponent = Component;
 
     return RouteHandler;
 }


### PR DESCRIPTION
This allows easy access to the underlying component for tests as in `react-intl`:
https://github.com/yahoo/react-intl/blob/master/src/inject.js#L32
https://github.com/yahoo/react-intl/wiki/Testing-with-React-Intl