### PR TITLE
Updated Fluxible API Docs for React Components to React v15

### DIFF
--- a/packages/fluxible/docs/api/Components.md
+++ b/packages/fluxible/docs/api/Components.md
@@ -157,7 +157,8 @@ describe('TestComponent', function () {
 
             // React must be required after window is set
             React = require('react');
-            ReactTestUtils = require('react/lib/ReactTestUtils');
+            ReactDOM = require('react-dom');
+            ReactTestUtils = require('react-addons-test-utils');
             provideContext = require('fluxible-addons-react/provideContext');
             connectToStores = require('fluxible-addons-react/connectToStores');
 
@@ -194,7 +195,7 @@ describe('TestComponent', function () {
         var component = ReactTestUtils.renderIntoDocument(
             <TestComponent context={componentContext} />
         );
-        var node = component.getDOMNode();
+        var node = ReactDOM.findDOMNode(component);
         assert.equal('foo', node.innerHTML);
         ReactTestUtils.Simulate.click(node);
         assert.equal('foobar', node.innerHTML);


### PR DESCRIPTION
The [example Fluxible app](http://fluxible.io/quick-start.html) uses React 15.0.0-rc.1. I cloned the example Fluxible app and applied the example test code shown in these API documentation posts to it [in my own repo here](https://github.com/ltfschoen/react-fluxible-test), however I encountered errors when applying the sample test code snippets shown this page, since some major changes mentioned in this [React Upgrade Guide](https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html) give errors in React v15 now that it has been released. To make the example test code in this post work with both React v15.0.0-rc.1 and the latest v15.4.1 the following changes were made: 

- Imported `react-addons-test-utils` (installed with `npm install --save-dev react-addons-test-utils`) and used it instead of `'react/lib/ReactTestUtils'`, which is deprecated and results in error `Uncaught Error: Cannot find module 'react/lib/ReactTestUtils'` if used in React v15 where many add-ons have now moved into a separate packages.

- Replaced `getDOMNode()` (deprecated) with `ReactDOM.findDOMNode(component)`, to overcome error ` TypeError: component.getDOMNode is not a function` in React v15.

My system:
- React 15.4.1
- ReactDOM 15.4.1
- react-addons-test-utils v15.4.1
- Node.js (changes tested on both latest node v7.3.0 and older v6.6)