### PR TITLE
skip updating scroll when it is not changed

### DIFF
--- a/packages/fluxible-router/lib/handleHistory.js
+++ b/packages/fluxible-router/lib/handleHistory.js
@@ -210,9 +210,17 @@ function createComponent(Component, opts) {
         },
         _saveScrollPosition: function (e) {
             var historyState = (this._history.getState && this._history.getState()) || {};
+            var scrollX = window.scrollX || window.pageXOffset;
+            var scrollY = window.scrollY || window.pageYOffset;
+            // reduce unused replaceState
+            // also prevent IOS Safari reset scroll position to 0 with universal link bar showing
+            if (historyState.scroll && historyState.scroll.x === scrollX && historyState.scroll.y === scrollY) {
+                debug('skip updating scrolling position with same position', historyState.scroll);
+                return;
+            }
             historyState.scroll = {
-                x: window.scrollX || window.pageXOffset,
-                y: window.scrollY || window.pageYOffset
+                x: scrollX,
+                y: scrollY
             };
             debug('remember scroll position', historyState.scroll);
             this._history.replaceState(historyState);

--- a/packages/fluxible-router/tests/unit/lib/handleHistory-test.js
+++ b/packages/fluxible-router/tests/unit/lib/handleHistory-test.js
@@ -26,12 +26,13 @@ var TestRouteStore = RouteStore.withStaticRoutes({
 
 var testResult = {};
 var historyMock = function (url, state) {
+    var states = [state];
     return {
         getUrl: function () {
             return url || '/the_path_from_history';
         },
         getState: function () {
-            return state;
+            return states.slice(-1)[0];
         },
         on: function (listener) {
             testResult.historyMockOn = listener;
@@ -40,18 +41,22 @@ var historyMock = function (url, state) {
             testResult.historyMockOn = null;
         },
         pushState: function (state, title, url) {
-            testResult.pushState = {
+            states.push(state);
+            testResult.pushState = testResult.pushState || [];
+            testResult.pushState.push({
                 state: state,
                 title: title,
                 url: url
-            };
+            });
         },
         replaceState: function (state, title, url) {
-            testResult.replaceState = {
+            states[states.length - 1] = state;
+            testResult.replaceState = testResult.replaceState || [];
+            testResult.replaceState.push({
                 state: state,
                 title: title,
                 url: url
-            };
+            });
         }
     };
 };
@@ -218,11 +223,19 @@ describe('handleHistory', function () {
                     ReactTestUtils.renderIntoDocument(
                         <MockAppComponent context={mockContext} />
                     );
+                    window.scrollY = 0;
                     window.dispatchEvent(new Event('scroll'));
                     window.dispatchEvent(new Event('scroll'));
                     window.setTimeout(function() {
-                        expect(testResult.replaceState).to.eql({state: {scroll: {x: 0, y: 0}}, title: undefined, url: undefined});
-                        done();
+                        expect(testResult.replaceState.length).to.eql(1); // should just execute replaceState once since the second one doesn't change position
+                        expect(testResult.replaceState[0]).to.eql({state: {scroll: {x: 0, y: 0}}, title: undefined, url: undefined});
+                        window.scrollY = 100;
+                        window.dispatchEvent(new Event('scroll'));
+                        window.setTimeout(function() {
+                            expect(testResult.replaceState.length).to.eql(2);
+                            expect(testResult.replaceState[1]).to.eql({state: {scroll: {x: 0, y: 100}}, title: undefined, url: undefined});
+                            done();
+                        }, 150);
                     }, 150);
                 });
                 it('dispatch navigate event for pages that url does not match', function (done) {
@@ -447,7 +460,7 @@ describe('handleHistory', function () {
                         <MockAppComponent context={mockContext} />
                     );
                     routeStore._handleNavigateStart({url: '/bar', method: 'GET'});
-                    expect(testResult.pushState).to.eql({state: {params: {}, query: {}, scroll: {x: 0, y: 0}}, title: null, url: '/bar'});
+                    expect(testResult.pushState[0]).to.eql({state: {params: {}, query: {}, scroll: {x: 0, y: 0}}, title: null, url: '/bar'});
                     expect(testResult.scrollTo).to.eql({x: 0, y: 0});
                 });
                 it('update with unicode route, navigate.type=click, reset scroll position', function () {
@@ -462,7 +475,7 @@ describe('handleHistory', function () {
                         <MockAppComponent context={mockContext} />
                     );
                     routeStore._handleNavigateStart({url: '/föö', method: 'GET'});
-                    expect(testResult.pushState).to.eql({state: {params: {}, query: {}, scroll: {x: 0, y: 0}}, title: null, url: '/föö'});
+                    expect(testResult.pushState[0]).to.eql({state: {params: {}, query: {}, scroll: {x: 0, y: 0}}, title: null, url: '/föö'});
                     expect(testResult.scrollTo).to.eql({x: 0, y: 0});
                 });
                 it('update with different route, navigate.type=click, enableScroll=false, do not reset scroll position', function () {
@@ -478,7 +491,7 @@ describe('handleHistory', function () {
                         <MockAppComponent context={mockContext} />
                     );
                     routeStore._handleNavigateStart({url: '/bar', method: 'GET'});
-                    expect(testResult.pushState).to.eql({state: {params: {}, query: {}, scroll: {x: 0, y: 0}}, title: null, url: '/bar'});
+                    expect(testResult.pushState[0]).to.eql({state: {params: {}, query: {}, scroll: {x: 0, y: 0}}, title: null, url: '/bar'});
                     expect(testResult.scrollTo).to.equal(undefined);
                 });
                 it('update with different route, navigate.type=replacestate, enableScroll=false, do not reset scroll position', function () {
@@ -494,7 +507,7 @@ describe('handleHistory', function () {
                         <MockAppComponent context={mockContext} />
                     );
                     routeStore._handleNavigateStart({url: '/bar', method: 'GET', type: 'replacestate'});
-                    expect(testResult.replaceState).to.eql({state: {params: {}, query: {}, scroll: {x: 0, y: 0}}, title: null, url: '/bar'});
+                    expect(testResult.replaceState[0]).to.eql({state: {params: {}, query: {}, scroll: {x: 0, y: 0}}, title: null, url: '/bar'});
                     expect(testResult.scrollTo).to.equal(undefined);
                 });
                 it('update with different route, navigate.type=default, reset scroll position', function () {
@@ -509,7 +522,7 @@ describe('handleHistory', function () {
                         <MockAppComponent context={mockContext} />
                     );
                     routeStore._handleNavigateStart({url: '/bar', method: 'GET'});
-                    expect(testResult.pushState).to.eql({state: {params: {}, query: {}, scroll: {x: 0, y: 0} }, title: null, url: '/bar'});
+                    expect(testResult.pushState[0]).to.eql({state: {params: {}, query: {}, scroll: {x: 0, y: 0} }, title: null, url: '/bar'});
                     expect(testResult.scrollTo).to.eql({x: 0, y: 0});
                 });
                 it('update with different route, navigate.type=default, enableScroll=false, do not reset scroll position', function () {
@@ -525,7 +538,7 @@ describe('handleHistory', function () {
                         <MockAppComponent context={mockContext} />
                     );
                     routeStore._handleNavigateStart({url: '/bar', method: 'GET'});
-                    expect(testResult.pushState).to.eql({state: {params: {}, query: {}, scroll: {x: 0, y: 0}}, title: null, url: '/bar'});
+                    expect(testResult.pushState[0]).to.eql({state: {params: {}, query: {}, scroll: {x: 0, y: 0}}, title: null, url: '/bar'});
                     expect(testResult.scrollTo).to.equal(undefined);
                 });
                 it('do not pushState, navigate.type=popstate, restore scroll position', function () {
@@ -572,7 +585,7 @@ describe('handleHistory', function () {
                         <MockAppComponent context={mockContext} />
                     );
                     routeStore._handleNavigateStart({url: '/bar', type: 'click', params: {foo: 'bar'}});
-                    expect(testResult.pushState.state.scroll).to.eql(undefined);
+                    expect(testResult.pushState[0].state.scroll).to.eql(undefined);
                 });
                 it('update with different route, navigate.type=click, with params', function () {
                     var routeStore = mockContext.getStore('RouteStore');
@@ -586,7 +599,7 @@ describe('handleHistory', function () {
                         <MockAppComponent context={mockContext} />
                     );
                     routeStore._handleNavigateStart({url: '/bar', type: 'click', params: {foo: 'bar'}});
-                    expect(testResult.pushState).to.eql({state: {params: {foo: 'bar'}, query: {}, scroll: {x: 0, y: 0}}, title: null, url: '/bar'});
+                    expect(testResult.pushState[0]).to.eql({state: {params: {foo: 'bar'}, query: {}, scroll: {x: 0, y: 0}}, title: null, url: '/bar'});
                 });
                 it('update with same path and different hash, navigate.type=click, with params', function () {
                     var routeStore = mockContext.getStore('RouteStore');
@@ -600,7 +613,7 @@ describe('handleHistory', function () {
                         <MockAppComponent context={mockContext} />
                     );
                     routeStore._handleNavigateStart({url: '/foo#hash2', type: 'click', params: {foo: 'bar'}});
-                    expect(testResult.pushState).to.eql({state: {params: {foo: 'bar'}, query: {}, scroll: {x: 0, y: 0}}, title: null, url: '/foo#hash2'});
+                    expect(testResult.pushState[0]).to.eql({state: {params: {foo: 'bar'}, query: {}, scroll: {x: 0, y: 0}}, title: null, url: '/foo#hash2'});
                 });
                 it('update with different route, navigate.type=replacestate, with params', function () {
                     var routeStore = mockContext.getStore('RouteStore');
@@ -614,7 +627,7 @@ describe('handleHistory', function () {
                         <MockAppComponent context={mockContext} />
                     );
                     routeStore._handleNavigateStart({url: '/bar', method: 'GET', type: 'replacestate', params: {foo: 'bar'}});
-                    expect(testResult.replaceState).to.eql({state: {params: {foo: 'bar'}, query: {}, scroll: {x: 0, y: 0}}, title: null, url: '/bar'});
+                    expect(testResult.replaceState[0]).to.eql({state: {params: {foo: 'bar'}, query: {}, scroll: {x: 0, y: 0}}, title: null, url: '/bar'});
                 });
                 it('update with different route, navigate.type=replacestate', function () {
                     var routeStore = mockContext.getStore('RouteStore');
@@ -628,7 +641,7 @@ describe('handleHistory', function () {
                         <MockAppComponent context={mockContext} />
                     );
                     routeStore._handleNavigateStart({url: '/bar', method: 'GET', type: 'replacestate'});
-                    expect(testResult.replaceState).to.eql({state: {params: {}, query: {}, scroll: {x: 0, y: 0}}, title: null, url: '/bar'});
+                    expect(testResult.replaceState[0]).to.eql({state: {params: {}, query: {}, scroll: {x: 0, y: 0}}, title: null, url: '/bar'});
                 });
                 it('update with different route, navigate.type=pushstate, preserve scroll state', function () {
                     global.window.scrollX = 42;
@@ -644,7 +657,7 @@ describe('handleHistory', function () {
                         <MockAppComponent context={mockContext} />
                     );
                     routeStore._handleNavigateStart({url: '/bar', method: 'GET', type: 'click', preserveScrollPosition: true});
-                    expect(testResult.pushState).to.eql({state: {params: {}, query: {}, scroll: {x: 42, y: 3}}, title: null, url: '/bar'});
+                    expect(testResult.pushState[0]).to.eql({state: {params: {}, query: {}, scroll: {x: 42, y: 3}}, title: null, url: '/bar'});
                 });
                 it('update with different route, navigate.type=replacestate, preserve scroll state', function () {
                     global.window.scrollX = 42;
@@ -660,7 +673,7 @@ describe('handleHistory', function () {
                         <MockAppComponent context={mockContext} />
                     );
                     routeStore._handleNavigateStart({url: '/bar', method: 'GET', type: 'replacestate', preserveScrollPosition: true});
-                    expect(testResult.replaceState).to.eql({state: {params: {}, query: {}, scroll: {x: 42, y: 3}}, title: null, url: '/bar'});
+                    expect(testResult.replaceState[0]).to.eql({state: {params: {}, query: {}, scroll: {x: 42, y: 3}}, title: null, url: '/bar'});
                 });
             });
         });


### PR DESCRIPTION
@lingyan @redonkulus 

on scroll we keep using replaceState to update scroll position, while this causes an unexpected behavior on IOS Safari with universal links bar showing.

The issue is when it shows and we try to replaceState, browser will try to reset the scroll position to 0 and hide the bar. 

The solution here is don't update state when scroll position remain unchanged. It's unused anyways and we should just prevent duplicated action. 