### PR TITLE
Throw correct 'store has no method' error

### DIFF
--- a/packages/dispatchr/lib/DispatcherContext.js
+++ b/packages/dispatchr/lib/DispatcherContext.js
@@ -103,7 +103,7 @@ DispatcherContext.prototype.dispatch = function dispatch(actionName, payload) {
                     var meta = {
                         store: store
                     };
-                    return this.dispatcher._throwOrCallErrorHandler(message, 'DISPATCH_INVALID_STORE_METHOD', this.context, meta);
+                    return self.dispatcher._throwOrCallErrorHandler(message, 'DISPATCH_INVALID_STORE_METHOD', self.context, meta);
                 }
                 handlerFns[store.name] = storeInstance[store.handler].bind(storeInstance);
             }

--- a/packages/dispatchr/tests/unit/lib/Dispatcher.js
+++ b/packages/dispatchr/tests/unit/lib/Dispatcher.js
@@ -176,7 +176,7 @@ describe('Dispatchr', function () {
                 dispatcherContext = dispatcher.createContext(context);
             expect(function () {
                 dispatcherContext.dispatch('ERROR', {});
-            }).to['throw']();
+            }).to['throw']('Store does not have a method called error');
             // Should still allow calling another dispatch
             dispatcherContext.dispatch('DELAY', {});
         });


### PR DESCRIPTION
My app was throwing an error "Cannot read property 'dispatcher' of undefined" which is misleading, since the correct error message should have been "Store does not have a method called [...]". This PR fixes that, with updated tests.