### PR TITLE
Added create-react-class for React 15.5 support

### DIFF
--- a/packages/fluxible-addons-react/package.json
+++ b/packages/fluxible-addons-react/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "hoist-non-react-statics": "^1.0.4",
-    "inherits": "^2.0.1"
+    "inherits": "^2.0.1",
+    "create-react-class": "^15.5.1"
   },
   "peerDependencies": {
     "fluxible": ">=1.0.0",

--- a/packages/fluxible-addons-react/provideContext.js
+++ b/packages/fluxible-addons-react/provideContext.js
@@ -9,7 +9,7 @@ var hoistNonReactStatics = require('hoist-non-react-statics');
 var inherits = require('inherits');
 
 function createComponent(Component, customContextTypes) {
-    var componentName = Component.displayName || Component.name;
+    var componentName = Component.displayName || Component.name || 'Component';
     var childContextTypes = Object.assign({
         executeAction: React.PropTypes.func.isRequired,
         getStore: React.PropTypes.func.isRequired

--- a/packages/fluxible-addons-react/tests/unit/lib/FluxibleComponent.js
+++ b/packages/fluxible-addons-react/tests/unit/lib/FluxibleComponent.js
@@ -8,6 +8,7 @@ var ReactTestUtils;
 var connectToStores;
 var provideContext;
 var FluxibleComponent;
+var createReactClass;
 var FooStore = require('../../fixtures/stores/FooStore');
 var BarStore = require('../../fixtures/stores/BarStore');
 var createMockComponentContext = require('fluxible/utils/createMockComponentContext');
@@ -33,6 +34,7 @@ describe('fluxible-addons-react', function () {
 
                 React = require('react');
                 ReactDOM = require('react-dom');
+                createReactClass = require('create-react-class');
                 ReactTestUtils = require('react-addons-test-utils');
                 connectToStores = require('../../../').connectToStores;
                 provideContext = require('../../../').provideContext;
@@ -49,7 +51,7 @@ describe('fluxible-addons-react', function () {
         });
 
         it('will not double render', function () {
-            const Component = React.createClass({
+            const Component = createReactClass({
                 render: function () {
                     return (
                         <div className="Component">{this.props.children}</div>
@@ -66,7 +68,7 @@ describe('fluxible-addons-react', function () {
         });
 
         it('should pass context prop to child', function (done) {
-            const Component = React.createClass({
+            const Component = createReactClass({
                 render: function () {
                     expect(this.props.context).to.equal(context);
                     done();

--- a/packages/fluxible-addons-react/tests/unit/lib/FluxibleMixin.js
+++ b/packages/fluxible-addons-react/tests/unit/lib/FluxibleMixin.js
@@ -3,8 +3,9 @@
 
 var expect = require('chai').expect,
     React = require('react'),
-    ReactDOM =require('react-dom/server'),
+    ReactDOM = require('react-dom/server'),
     ReactTestUtils = require('react-addons-test-utils'),
+    createReactClass = require('create-react-class'),
     provideContext = require('../../../provideContext'),
     FluxibleMixin = require('../../../').FluxibleMixin,
     createStore = require('fluxible/addons/createStore'),
@@ -56,7 +57,7 @@ describe('fluxible-addons-react', function () {
                 expect(FluxibleMixin._fluxible_listeners).to.be.empty;
             });
             it('should register static listener array', function (done) {
-                var Component = provideContext(React.createClass({
+                var Component = provideContext(createReactClass({
                     mixins: [FluxibleMixin],
                     statics: {
                         storeListeners: [MockStore]
@@ -74,7 +75,7 @@ describe('fluxible-addons-react', function () {
                 mockStore.emitChange();
             });
             it('should register static listener object', function (done) {
-                var Component = provideContext(React.createClass({
+                var Component = provideContext(createReactClass({
                     mixins: [FluxibleMixin],
                     statics: {
                         storeListeners: {
@@ -94,7 +95,7 @@ describe('fluxible-addons-react', function () {
                 mockStore.emitChange();
             });
             it('should register static listener object with array', function (done) {
-                var Component = provideContext(React.createClass({
+                var Component = provideContext(createReactClass({
                     mixins: [FluxibleMixin],
                     statics: {
                         storeListeners: {
@@ -117,7 +118,7 @@ describe('fluxible-addons-react', function () {
 
         describe('iterating over storeListeners', function () {
             it('should expose iterables for static listener array', function () {
-                var Component = provideContext(React.createClass({
+                var Component = provideContext(createReactClass({
                     mixins: [FluxibleMixin],
                     statics: {
                         storeListeners: [MockStore, MockStore2]
@@ -134,7 +135,7 @@ describe('fluxible-addons-react', function () {
                 expect(component.refs.wrappedElement.getListeners(), 'getListeners').to.have.length(2);
             });
             it('should expose iterables for static listener object', function () {
-                var Component = provideContext(React.createClass({
+                var Component = provideContext(createReactClass({
                     mixins: [FluxibleMixin],
                     statics: {
                         storeListeners: {
@@ -156,7 +157,7 @@ describe('fluxible-addons-react', function () {
                 expect(component.refs.wrappedElement.getListeners(), 'getListeners').to.have.length(2);
             });
             it('should expose iterables for static listener object with array', function () {
-                var Component = provideContext(React.createClass({
+                var Component = provideContext(createReactClass({
                     mixins: [FluxibleMixin],
                     statics: {
                         storeListeners: {
@@ -197,7 +198,7 @@ describe('fluxible-addons-react', function () {
 
         describe('executeAction', function () {
             it('should throw when no context provided', function () {
-                var Component = React.createClass({
+                var Component = createReactClass({
                     mixins: [FluxibleMixin],
                     getInitialState: function () {
                         this.executeAction(function () {
@@ -215,7 +216,7 @@ describe('fluxible-addons-react', function () {
                 }).to['throw']();
             });
             it('should call context executeAction when context provided', function (done) {
-                var Component = React.createClass({
+                var Component = createReactClass({
                     mixins: [FluxibleMixin],
                     componentDidMount: function () {
                         this.executeAction(function () {
@@ -233,7 +234,7 @@ describe('fluxible-addons-react', function () {
             });
             it('should call context executeAction when context provided via React context', function (done) {
                 var FluxibleComponent = require('../../../').FluxibleComponent;
-                var Component = React.createClass({
+                var Component = createReactClass({
                     displayName: 'Component',
                     contextTypes: {
                         executeAction: React.PropTypes.func.isRequired

--- a/packages/fluxible-addons-react/tests/unit/lib/batchedUpdatePlugin.js
+++ b/packages/fluxible-addons-react/tests/unit/lib/batchedUpdatePlugin.js
@@ -11,6 +11,7 @@ var FooStore = require('../../fixtures/stores/FooStore');
 var BarStore = require('../../fixtures/stores/BarStore');
 var Fluxible = require('fluxible');
 var jsdom = require('jsdom');
+var createReactClass = require('create-react-class');
 
 describe('fluxible-addons-react', function () {
     describe('connectToStores', function () {
@@ -52,7 +53,7 @@ describe('fluxible-addons-react', function () {
 
         it('should only call render once when two stores emit changes', function (done) {
             var i = 0;
-            var Component = React.createClass({
+            var Component = createReactClass({
                 componentDidUpdate: function () {
                     i++;
                 },

--- a/packages/fluxible-addons-react/tests/unit/lib/connectToStores.js
+++ b/packages/fluxible-addons-react/tests/unit/lib/connectToStores.js
@@ -7,6 +7,7 @@ var ReactDOM;
 var ReactTestUtils;
 var connectToStores;
 var provideContext;
+var createReactClass;
 var FooStore = require('../../fixtures/stores/FooStore');
 var BarStore = require('../../fixtures/stores/BarStore');
 var createMockComponentContext = require('fluxible/utils/createMockComponentContext');
@@ -32,6 +33,7 @@ describe('fluxible-addons-react', function () {
 
                 React = require('react');
                 ReactDOM = require('react-dom');
+                createReactClass = require('create-react-class');
                 ReactTestUtils = require('react-addons-test-utils');
                 connectToStores = require('../../../').connectToStores;
                 provideContext = require('../../../').provideContext;
@@ -47,7 +49,7 @@ describe('fluxible-addons-react', function () {
         });
 
         it('should get the state from the stores', function (done) {
-            var Component = React.createClass({
+            var Component = createReactClass({
                 contextTypes: {
                     executeAction: React.PropTypes.func.isRequired
                 },
@@ -204,7 +206,7 @@ describe('fluxible-addons-react', function () {
         });
 
         it('should hoist non-react statics to higher order component', function () {
-            var Component = React.createClass({
+            var Component = createReactClass({
                 displayName: 'Component',
                 statics: {
                     initAction: function () {

--- a/packages/fluxible-addons-react/tests/unit/lib/provideContext.js
+++ b/packages/fluxible-addons-react/tests/unit/lib/provideContext.js
@@ -5,6 +5,7 @@ var expect = require('chai').expect;
 var React = require('react');
 var renderToString = require('react-dom/server').renderToString;
 var render = require('react-dom').render;
+var createReactClass = require('create-react-class');
 var provideContext = require('../../..').provideContext;
 var jsdom = require('jsdom');
 
@@ -30,7 +31,7 @@ describe('fluxible-addons-react', function () {
         });
 
         it('should use the childs name', function () {
-            var Component = React.createClass({
+            var Component = createReactClass({
                 render: function () {
                     return null;
                 }
@@ -41,7 +42,7 @@ describe('fluxible-addons-react', function () {
         });
 
         it('should use the childs displayName', function () {
-            var Component = React.createClass({
+            var Component = createReactClass({
                 displayName: 'TestComponent',
                 render: function () {
                     return null;
@@ -60,7 +61,7 @@ describe('fluxible-addons-react', function () {
                 getStore: function () {
                 }
             };
-            var Component = React.createClass({
+            var Component = createReactClass({
                 contextTypes: {
                     foo: React.PropTypes.string.isRequired,
                     executeAction: React.PropTypes.func.isRequired,
@@ -88,7 +89,7 @@ describe('fluxible-addons-react', function () {
                 getStore: function () {
                 }
             };
-            var Component = React.createClass({
+            var Component = createReactClass({
                 displayName: 'Component',
                 statics: {
                     initAction: function () {

--- a/packages/fluxible-router/lib/createNavLinkComponent.js
+++ b/packages/fluxible-router/lib/createNavLinkComponent.js
@@ -9,6 +9,7 @@ var RouteStore = require('./RouteStore');
 var debug = require('debug')('NavLink');
 var navigateAction = require('./navigateAction');
 var __DEV__ = process.env.NODE_ENV !== 'production';
+var createReactClass = require('create-react-class');
 
 function objectWithoutProperties(obj, keys) {
     var target = {};
@@ -67,7 +68,7 @@ function getRelativeHref(href) {
  * @returns {React.Component} NavLink component
  */
 module.exports = function createNavLinkComponent (overwriteSpec) {
-    var NavLink = React.createClass(Object.assign({}, {
+    var NavLink = createReactClass(Object.assign({}, {
         autobind: false,
         displayName: 'NavLink',
         contextTypes: {

--- a/packages/fluxible-router/package.json
+++ b/packages/fluxible-router/package.json
@@ -24,7 +24,8 @@
     "fluxible-addons-react": "^0.2.0",
     "hoist-non-react-statics": "^1.0.4",
     "inherits": "^2.0.1",
-    "routr": "^2.0.0"
+    "routr": "^2.0.0",
+    "create-react-class": "^15.5.1"
   },
   "peerDependencies": {
     "fluxible": "^1.0.0",

--- a/packages/fluxible-router/tests/mocks/MockAppComponent.js
+++ b/packages/fluxible-router/tests/mocks/MockAppComponent.js
@@ -6,8 +6,9 @@
 var React = require('react');
 var provideContext = require('fluxible-addons-react/provideContext');
 var handleHistory = require('../../lib/handleHistory');
+var createReactClass = require('create-react-class');
 
-var MockAppComponent = React.createClass({
+var MockAppComponent = createReactClass({
     contextTypes: {
         getStore: React.PropTypes.func.isRequired
     },

--- a/packages/fluxible-router/tests/unit/lib/handleHistory-test.js
+++ b/packages/fluxible-router/tests/unit/lib/handleHistory-test.js
@@ -7,6 +7,7 @@ var expect = require('chai').expect;
 var jsdom = require('jsdom');
 var React;
 var ReactDOM;
+var createReactClass;
 var mockCreators = {
     wrappedCreator: 'createWrappedMockAppComponent',
     decoratedCreator: 'createDecoratedMockAppComponent'
@@ -88,6 +89,7 @@ describe('handleHistory', function () {
 
             React = require('react');
             ReactDOM = require('react-dom');
+            createReactClass = require('create-react-class');
             provideContext = require('fluxible-addons-react/provideContext');
             handleHistory = require('../../../lib/handleHistory');
             MockAppComponentLib = require('../../mocks/MockAppComponent');
@@ -108,7 +110,7 @@ describe('handleHistory', function () {
 
     describe('statics', function () {
         it('should hoist non-react statics to wrapper', function () {
-            var App = React.createClass({
+            var App = createReactClass({
                 displayName: 'Child',
                 statics: {
                     initAction: function () {}
@@ -163,7 +165,7 @@ describe('handleHistory', function () {
                     var rendered = false;
                     var routeStore = mockContext.getStore('RouteStore');
                     routeStore._handleNavigateStart({url: '/foo', method: 'GET'});
-                    var Child = React.createClass({
+                    var Child = createReactClass({
                         displayName: 'Child',
                         render: function () {
                             rendered = true;


### PR DESCRIPTION
Switched out React.createClass for create-react-class in fluxible-addons-react and fluxible-router due to API change in React v15.5.