### PR TITLE
Suppress deprecation message 

### DIFF
--- a/packages/fluxible-addons-react/FluxibleComponent.js
+++ b/packages/fluxible-addons-react/FluxibleComponent.js
@@ -5,6 +5,7 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
 var inherits = require('inherits');
 
 function FluxibleComponent(props, context) {
@@ -15,11 +16,11 @@ inherits(FluxibleComponent, React.Component);
 
 FluxibleComponent.displayName = 'FluxibleComponent';
 FluxibleComponent.propTypes = {
-    context: React.PropTypes.object.isRequired
+    context: PropTypes.object.isRequired
 };
 FluxibleComponent.childContextTypes = {
-    executeAction: React.PropTypes.func.isRequired,
-    getStore: React.PropTypes.func.isRequired
+    executeAction: PropTypes.func.isRequired,
+    getStore: PropTypes.func.isRequired
 };
 
 Object.assign(FluxibleComponent.prototype, {

--- a/packages/fluxible-addons-react/FluxibleMixin.js
+++ b/packages/fluxible-addons-react/FluxibleMixin.js
@@ -36,12 +36,13 @@
  */
 var DEFAULT_CHANGE_HANDLER = 'onChange';
 var React = require('react');
+var PropTypes = require('prop-types');
 
 var FluxibleMixin = {
 
     contextTypes: {
-        executeAction: React.PropTypes.func,
-        getStore: React.PropTypes.func
+        executeAction: PropTypes.func,
+        getStore: PropTypes.func
     },
 
     /**

--- a/packages/fluxible-addons-react/connectToStores.js
+++ b/packages/fluxible-addons-react/connectToStores.js
@@ -5,13 +5,14 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
 var inherits = require('inherits');
 var hoistNonReactStatics = require('hoist-non-react-statics');
 
 function createComponent(Component, stores, getStateFromStores, customContextTypes) {
     var componentName = Component.displayName || Component.name;
     var componentContextTypes = Object.assign({
-        getStore: React.PropTypes.func.isRequired
+        getStore: PropTypes.func.isRequired
     }, customContextTypes);
 
     function StoreConnector(props, context) {

--- a/packages/fluxible-addons-react/docs/api/FluxibleComponent.md
+++ b/packages/fluxible-addons-react/docs/api/FluxibleComponent.md
@@ -21,8 +21,8 @@ class Component extends React.Component {
     }
 }
 Component.contextTypes = {
-    getStore: React.PropTypes.func.isRequired,
-    executeAction: React.PropTypes.func.isRequired
+    getStore: PropTypes.func.isRequired,
+    executeAction: PropTypes.func.isRequired
 };
 ```
 

--- a/packages/fluxible-addons-react/docs/api/provideContext.md
+++ b/packages/fluxible-addons-react/docs/api/provideContext.md
@@ -55,7 +55,7 @@ second parameter.
 
 ```js
 Application = provideContext(Application, {
-    foo: React.PropTypes.string
+    foo: PropTypes.string
 });
 ```
 
@@ -74,7 +74,7 @@ more information on the proposal.***
 
 ```js
 @provideContext({
-    foo: React.PropTypes.string
+    foo: PropTypes.string
 })
 class Application extends React.Component {
     render() {

--- a/packages/fluxible-addons-react/package.json
+++ b/packages/fluxible-addons-react/package.json
@@ -19,11 +19,13 @@
   },
   "peerDependencies": {
     "fluxible": ">=1.0.0",
+    "prop-types": "^15.5.8",
     "react": "^0.14.0 || ^15.0.0-rc.1",
     "react-dom": "^0.14.0 || ^15.0.0-rc.1"
   },
   "devDependencies": {
     "fluxible": ">=1.0.0",
+    "prop-types": "^15.5.8",
     "react": "^15.0.0-rc.1",
     "react-dom": "^15.0.0-rc.1"
   },

--- a/packages/fluxible-addons-react/package.json
+++ b/packages/fluxible-addons-react/package.json
@@ -15,17 +15,16 @@
   "dependencies": {
     "hoist-non-react-statics": "^1.0.4",
     "inherits": "^2.0.1",
-    "create-react-class": "^15.5.1"
+    "create-react-class": "^15.5.1",
+    "prop-types": "^15.5.8"
   },
   "peerDependencies": {
     "fluxible": ">=1.0.0",
-    "prop-types": "^15.5.8",
     "react": "^0.14.0 || ^15.0.0-rc.1",
     "react-dom": "^0.14.0 || ^15.0.0-rc.1"
   },
   "devDependencies": {
     "fluxible": ">=1.0.0",
-    "prop-types": "^15.5.8",
     "react": "^15.0.0-rc.1",
     "react-dom": "^15.0.0-rc.1"
   },

--- a/packages/fluxible-addons-react/provideContext.js
+++ b/packages/fluxible-addons-react/provideContext.js
@@ -5,14 +5,15 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
 var hoistNonReactStatics = require('hoist-non-react-statics');
 var inherits = require('inherits');
 
 function createComponent(Component, customContextTypes) {
     var componentName = Component.displayName || Component.name || 'Component';
     var childContextTypes = Object.assign({
-        executeAction: React.PropTypes.func.isRequired,
-        getStore: React.PropTypes.func.isRequired
+        executeAction: PropTypes.func.isRequired,
+        getStore: PropTypes.func.isRequired
     }, customContextTypes || {});
 
     function ContextProvider(props, context) {
@@ -23,7 +24,7 @@ function createComponent(Component, customContextTypes) {
 
     ContextProvider.displayName = 'contextProvider(' + componentName + ')';
     ContextProvider.propTypes = {
-        context: React.PropTypes.object.isRequired
+        context: PropTypes.object.isRequired
     };
     ContextProvider.childContextTypes = childContextTypes;
 
@@ -57,12 +58,12 @@ function createComponent(Component, customContextTypes) {
  *
  * Example:
  *   var WrappedComponent = provideContext(Component, {
- *       foo: React.PropTypes.string
+ *       foo: PropTypes.string
  *   });
  *
  * Also supports the decorator pattern:
  *   @provideContext({
- *       foo: React.PropTypes.string
+ *       foo: PropTypes.string
  *   })
  *   class ConnectedComponent extends React.Component {
  *       render() {

--- a/packages/fluxible-addons-react/tests/unit/lib/FluxibleMixin.js
+++ b/packages/fluxible-addons-react/tests/unit/lib/FluxibleMixin.js
@@ -3,6 +3,7 @@
 
 var expect = require('chai').expect,
     React = require('react'),
+    PropTypes = require('prop-types'),
     ReactDOM = require('react-dom/server'),
     ReactTestUtils = require('react-addons-test-utils'),
     createReactClass = require('create-react-class'),
@@ -237,7 +238,7 @@ describe('fluxible-addons-react', function () {
                 var Component = createReactClass({
                     displayName: 'Component',
                     contextTypes: {
-                        executeAction: React.PropTypes.func.isRequired
+                        executeAction: PropTypes.func.isRequired
                     },
                     componentDidMount: function () {
                         this.context.executeAction(function () {

--- a/packages/fluxible-addons-react/tests/unit/lib/connectToStores.js
+++ b/packages/fluxible-addons-react/tests/unit/lib/connectToStores.js
@@ -3,6 +3,7 @@
 
 var expect = require('chai').expect;
 var React;
+var PropTypes;
 var ReactDOM;
 var ReactTestUtils;
 var connectToStores;
@@ -33,6 +34,7 @@ describe('fluxible-addons-react', function () {
 
                 React = require('react');
                 ReactDOM = require('react-dom');
+                PropTypes = require('prop-types');
                 createReactClass = require('create-react-class');
                 ReactTestUtils = require('react-addons-test-utils');
                 connectToStores = require('../../../').connectToStores;
@@ -51,7 +53,7 @@ describe('fluxible-addons-react', function () {
         it('should get the state from the stores', function (done) {
             var Component = createReactClass({
                 contextTypes: {
-                    executeAction: React.PropTypes.func.isRequired
+                    executeAction: PropTypes.func.isRequired
                 },
                 onClick: function () {
                     this.context.executeAction(function (actionContext) {
@@ -104,7 +106,7 @@ describe('fluxible-addons-react', function () {
             //    };
             //}) class Component extends React.Component {
             //    static contextTypes = {
-            //        executeAction: React.PropTypes.func.isRequired
+            //        executeAction: PropTypes.func.isRequired
             //    };
             //
             //    onClick() {
@@ -152,7 +154,7 @@ describe('fluxible-addons-react', function () {
         // Decorators not supported with babel 6
         it.skip('should take customContextTypes using decorator pattern', function (done) {
             var customContextTypes = {
-                foo: React.PropTypes.func.isRequired
+                foo: PropTypes.func.isRequired
             };
             @connectToStores([], (context) => {
                 return {

--- a/packages/fluxible-addons-react/tests/unit/lib/provideContext.js
+++ b/packages/fluxible-addons-react/tests/unit/lib/provideContext.js
@@ -3,6 +3,7 @@
 
 var expect = require('chai').expect;
 var React = require('react');
+var PropTypes = require('prop-types');
 var renderToString = require('react-dom/server').renderToString;
 var render = require('react-dom').render;
 var createReactClass = require('create-react-class');
@@ -63,9 +64,9 @@ describe('fluxible-addons-react', function () {
             };
             var Component = createReactClass({
                 contextTypes: {
-                    foo: React.PropTypes.string.isRequired,
-                    executeAction: React.PropTypes.func.isRequired,
-                    getStore: React.PropTypes.func.isRequired
+                    foo: PropTypes.string.isRequired,
+                    executeAction: PropTypes.func.isRequired,
+                    getStore: PropTypes.func.isRequired
                 },
                 render: function () {
                     expect(this.context.foo).to.equal(context.foo);
@@ -75,7 +76,7 @@ describe('fluxible-addons-react', function () {
                 }
             });
             var WrappedComponent = provideContext(Component, {
-                foo: React.PropTypes.string
+                foo: PropTypes.string
             });
 
             renderToString(<WrappedComponent context={context}/>);
@@ -103,7 +104,7 @@ describe('fluxible-addons-react', function () {
                 }
             });
             var WrappedComponent = provideContext(Component, {
-                foo: React.PropTypes.string
+                foo: PropTypes.string
             });
 
             expect(WrappedComponent.initAction).to.be.a('function');
@@ -120,13 +121,13 @@ describe('fluxible-addons-react', function () {
                 }
             };
             @provideContext({
-                foo: React.PropTypes.string
+                foo: PropTypes.string
             })
             class WrappedComponent extends React.Component {
                 static contextTypes = {
-                    foo: React.PropTypes.string.isRequired,
-                    executeAction: React.PropTypes.func.isRequired,
-                    getStore: React.PropTypes.func.isRequired
+                    foo: PropTypes.string.isRequired,
+                    executeAction: PropTypes.func.isRequired,
+                    getStore: PropTypes.func.isRequired
                 };
 
                 render() {

--- a/packages/fluxible-router/lib/createNavLinkComponent.js
+++ b/packages/fluxible-router/lib/createNavLinkComponent.js
@@ -5,6 +5,7 @@
 /*global window,process */
 'use strict';
 var React = require('react');
+var PropTypes = require('prop-types');
 var RouteStore = require('./RouteStore');
 var debug = require('debug')('NavLink');
 var navigateAction = require('./navigateAction');
@@ -72,23 +73,23 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
         autobind: false,
         displayName: 'NavLink',
         contextTypes: {
-            executeAction: React.PropTypes.func.isRequired,
-            getStore: React.PropTypes.func.isRequired,
-            logger: React.PropTypes.object
+            executeAction: PropTypes.func.isRequired,
+            getStore: PropTypes.func.isRequired,
+            logger: PropTypes.object
         },
         propTypes: {
-            href: React.PropTypes.string,
-            stopPropagation: React.PropTypes.bool,
-            routeName: React.PropTypes.string,
-            navParams: React.PropTypes.object,
-            queryParams: React.PropTypes.object,
-            followLink: React.PropTypes.bool,
-            preserveScrollPosition: React.PropTypes.bool,
-            replaceState: React.PropTypes.bool,
-            validate: React.PropTypes.bool,
-            activeClass: React.PropTypes.string,
-            activeElement: React.PropTypes.string,
-            activeStyle: React.PropTypes.object
+            href: PropTypes.string,
+            stopPropagation: PropTypes.bool,
+            routeName: PropTypes.string,
+            navParams: PropTypes.object,
+            queryParams: PropTypes.object,
+            followLink: PropTypes.bool,
+            preserveScrollPosition: PropTypes.bool,
+            replaceState: PropTypes.bool,
+            validate: PropTypes.bool,
+            activeClass: PropTypes.string,
+            activeElement: PropTypes.string,
+            activeStyle: PropTypes.object
         },
         getInitialState: function () {
             return this._getState(this.props);

--- a/packages/fluxible-router/lib/handleHistory.js
+++ b/packages/fluxible-router/lib/handleHistory.js
@@ -5,6 +5,7 @@
 /*global window */
 'use strict';
 var React = require('react');
+var PropTypes = require('prop-types');
 var debug = require('debug')('FluxibleRouter:handleHistory');
 var handleRoute = require('../lib/handleRoute');
 var navigateAction = require('../lib/navigateAction');
@@ -62,11 +63,11 @@ function createComponent(Component, opts) {
 
     HistoryHandler.displayName = 'HistoryHandler';
     HistoryHandler.contextTypes = {
-        executeAction: React.PropTypes.func.isRequired
+        executeAction: PropTypes.func.isRequired
     };
     HistoryHandler.propTypes = {
-        currentRoute: React.PropTypes.object,
-        currentNavigate: React.PropTypes.object
+        currentRoute: PropTypes.object,
+        currentNavigate: PropTypes.object
     };
     HistoryHandler.defaultProps = {
         currentRoute: null,

--- a/packages/fluxible-router/lib/handleRoute.js
+++ b/packages/fluxible-router/lib/handleRoute.js
@@ -5,6 +5,7 @@
 /*global window */
 'use strict';
 var React = require('react');
+var PropTypes = require('prop-types');
 var connectToStores = require('fluxible-addons-react/connectToStores');
 var hoistNonReactStatics = require('hoist-non-react-statics');
 var inherits = require('inherits');
@@ -18,13 +19,13 @@ function createComponent(Component) {
 
     RouteHandler.displayName = 'RouteHandler';
     RouteHandler.contextTypes = {
-        getStore: React.PropTypes.func.isRequired
+        getStore: PropTypes.func.isRequired
     };
     RouteHandler.propTypes = {
-        currentRoute: React.PropTypes.object,
-        currentNavigate: React.PropTypes.object,
-        currentNavigateError: React.PropTypes.object,
-        isNavigateComplete: React.PropTypes.bool
+        currentRoute: PropTypes.object,
+        currentNavigate: PropTypes.object,
+        currentNavigateError: PropTypes.object,
+        isNavigateComplete: PropTypes.bool
     };
 
     Object.assign(RouteHandler.prototype, {
@@ -67,4 +68,3 @@ module.exports = function handleRoute(Component) {
 
     return createComponent.apply(null, arguments);
 };
-

--- a/packages/fluxible-router/package.json
+++ b/packages/fluxible-router/package.json
@@ -25,17 +25,16 @@
     "hoist-non-react-statics": "^1.0.4",
     "inherits": "^2.0.1",
     "routr": "^2.0.0",
-    "create-react-class": "^15.5.1"
+    "create-react-class": "^15.5.1",
+    "prop-types": "^15.5.8"
   },
   "peerDependencies": {
     "fluxible": "^1.0.0",
-    "prop-types": "^15.5.8",
     "react": "^0.14.0 || ^15.0.0-rc.1"
   },
   "devDependencies": {
     "fluxible": "^1.0.0",
     "lodash": "^3.2.0",
-    "prop-types": "^15.5.8",
     "react": "^15.0.0-rc.1",
     "react-dom": "^15.0.0-rc.1"
   },

--- a/packages/fluxible-router/package.json
+++ b/packages/fluxible-router/package.json
@@ -29,11 +29,13 @@
   },
   "peerDependencies": {
     "fluxible": "^1.0.0",
+    "prop-types": "^15.5.8",
     "react": "^0.14.0 || ^15.0.0-rc.1"
   },
   "devDependencies": {
     "fluxible": "^1.0.0",
     "lodash": "^3.2.0",
+    "prop-types": "^15.5.8",
     "react": "^15.0.0-rc.1",
     "react-dom": "^15.0.0-rc.1"
   },

--- a/packages/fluxible-router/tests/mocks/MockAppComponent.js
+++ b/packages/fluxible-router/tests/mocks/MockAppComponent.js
@@ -4,13 +4,14 @@
  */
 'use strict';
 var React = require('react');
+var PropTypes = require('prop-types');
 var provideContext = require('fluxible-addons-react/provideContext');
 var handleHistory = require('../../lib/handleHistory');
 var createReactClass = require('create-react-class');
 
 var MockAppComponent = createReactClass({
     contextTypes: {
-        getStore: React.PropTypes.func.isRequired
+        getStore: PropTypes.func.isRequired
     },
     render: function () {
         if (!this.props.children) {
@@ -23,7 +24,7 @@ var MockAppComponent = createReactClass({
 });
 
 var customContextTypes = {
-    logger: React.PropTypes.object
+    logger: PropTypes.object
 };
 module.exports = provideContext(handleHistory(MockAppComponent, {
     checkRouteOnPageLoad: false,
@@ -39,7 +40,7 @@ module.exports.createDecoratedMockAppComponent = function createDecoratedMockApp
     @handleHistory(opts)
     class DecoratedMockAppComponent extends React.Component {
         static contextTypes = {
-            getStore: React.PropTypes.func.isRequired
+            getStore: PropTypes.func.isRequired
         };
         constructor(props, context) {
             super(props, context);


### PR DESCRIPTION
Replace `React.PropTypes` with `prop-types` package to suppress following deprecation message.

```
Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.
```
