### PR TITLE
Replaced `isMounted()` with flags

### DIFF
--- a/packages/fluxible-addons-react/FluxibleMixin.js
+++ b/packages/fluxible-addons-react/FluxibleMixin.js
@@ -40,6 +40,8 @@ var PropTypes = require('prop-types');
 
 var FluxibleMixin = {
 
+    _isMounted: false,
+
     contextTypes: {
         executeAction: PropTypes.func,
         getStore: PropTypes.func
@@ -50,6 +52,7 @@ var FluxibleMixin = {
      * @method componentDidMount
      */
     componentDidMount: function componentDidMount() {
+        this._isMounted = true;
         this._fluxible_listeners = [];
         var self = this;
 
@@ -182,7 +185,7 @@ var FluxibleMixin = {
      * @private
      */
     _attachStoreListener: function _attachStoreListener(listener) {
-        if (this.isMounted && !this.isMounted()) {
+        if (!this._isMounted) {
             throw new Error('storeListener mixin called listen when component wasn\'t mounted.');
         }
 
@@ -200,6 +203,7 @@ var FluxibleMixin = {
                 listener.store.removeListener('change', listener.handler);
             });
         }
+        this._isMounted = false;
         this._fluxible_listeners = [];
     }
 };

--- a/packages/fluxible-router/lib/createNavLinkComponent.js
+++ b/packages/fluxible-router/lib/createNavLinkComponent.js
@@ -70,6 +70,7 @@ function getRelativeHref(href) {
  */
 module.exports = function createNavLinkComponent (overwriteSpec) {
     var NavLink = createReactClass(Object.assign({}, {
+        _isMounted: false,
         autobind: false,
         displayName: 'NavLink',
         contextTypes: {
@@ -104,11 +105,13 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             routeStore.removeChangeListener(this._onRouteStoreChange);
         },
         componentDidMount: function () {
+            this._isMounted = true;
             if (this.props.activeClass || this.props.activeStyle) {
                 this.startListening();
             }
         },
         componentWillUnmount: function () {
+            this._isMounted = false;
             if (this.props.activeClass || this.props.activeStyle) {
                 this.stopListening();
             }
@@ -135,7 +138,7 @@ module.exports = function createNavLinkComponent (overwriteSpec) {
             this.setState(this._getState(nextProps));
         },
         _onRouteStoreChange: function () {
-            if (this.isMounted()) {
+            if (this._isMounted) {
                 this.setState(this._getState(this.props));
             }
         },


### PR DESCRIPTION
Replaced `isMounted()` deprecated method used in listeners for RouteStore in FluxibleMixin and NavLink.