### PR TITLE
Use errorHandler for exceptions thrown inside stores

### DIFF
--- a/packages/dispatchr/lib/Dispatcher.js
+++ b/packages/dispatchr/lib/Dispatcher.js
@@ -156,6 +156,11 @@ Dispatcher.prototype._registerHandler = function registerHandler(action, name, h
  */
 Dispatcher.prototype._throwOrCallErrorHandler = function throwOrCallErrorHandler(message, type, context, meta) {
     if (this.errorHandler) {
+        meta = meta || {};
+        if (!meta.error) {
+            meta.error = new Error(message);
+        }
+
         this.errorHandler({
             message: message,
             type: type || 'DISPATCHER_ERROR',

--- a/packages/dispatchr/lib/DispatcherContext.js
+++ b/packages/dispatchr/lib/DispatcherContext.js
@@ -110,7 +110,11 @@ DispatcherContext.prototype.dispatch = function dispatch(actionName, payload) {
         });
         this.currentAction.execute(handlerFns);
     } catch (e) {
-        throw e;
+        var message = e.message;
+        var meta = {
+            error: e
+        };
+        return this.dispatcher._throwOrCallErrorHandler(message, 'DISPATCH_EXCEPTION', this.context, meta);
     } finally {
         debug('finished ' + actionName);
         this.currentAction = null;

--- a/packages/dispatchr/tests/mock/Store.js
+++ b/packages/dispatchr/tests/mock/Store.js
@@ -58,6 +58,10 @@ Store.prototype.rehydrate = function (state) {
     this.state = state;
 };
 
+Store.prototype.exception = function () {
+    throw new Error('Store handler error thrown');
+};
+
 Store.handlers = {
     'NAVIGATE': function navigate() {
         this.state.called = true;
@@ -67,7 +71,8 @@ Store.handlers = {
     'DELAY': 'delay',
     'ERROR': 'error',
     'DISPATCH': 'dispatch',
-    'WAITFOR': 'waitFor'
+    'WAITFOR': 'waitFor',
+    'EXCEPTION': 'exception'
 };
 
 module.exports = Store;

--- a/packages/dispatchr/tests/unit/lib/Dispatcher.js
+++ b/packages/dispatchr/tests/unit/lib/Dispatcher.js
@@ -263,6 +263,7 @@ describe('Dispatchr', function () {
                     expect(info).to.be.an('object');
                     expect(info.type).equal('REGISTER_STORE_NO_CONSTRUCTOR');
                     expect(info.message).equal('registerStore requires a constructor as first parameter');
+                    expect(info.meta.error).to.be.an.instanceOf(Error);
                     done();
                 }
             });
@@ -292,6 +293,7 @@ describe('Dispatchr', function () {
                         expect(info.type).equal('STORE_UNREGISTERED');
                         expect(info.message).equal('Store NewStore was not registered.');
                         expect(info.meta.storeName).equal('NewStore');
+                        expect(info.meta.error).to.be.an.instanceOf(Error);
                         done();
                     }
                 }),
@@ -300,6 +302,22 @@ describe('Dispatchr', function () {
 
             dispatcherContext.getStore(NewStore);
         });
+
+        it('should use the error handler when exceptions are thrown', function (done) {
+            var dispatcher = dispatchr.createDispatcher({
+                    stores: [mockStore],
+                    errorHandler: function (info, context) {
+                        expect(info.type).equal('DISPATCH_EXCEPTION');
+                        expect(info.message).equal('Store handler error thrown');
+                        expect(info.meta.error).to.be.an.instanceOf(Error);
+                        done();
+                    }
+                }),
+                context = {test: 'test'},
+                dispatcherContext = dispatcher.createContext(context);
+
+            dispatcherContext.dispatch('EXCEPTION', {});
+        })
     });
 
 });


### PR DESCRIPTION
I encountered a case in my app where certain exceptions were not handled by anything and bubbled up all the way to the main process.

I'm not sure what the intention was behind [re-throwing the error](https://github.com/yahoo/fluxible/blob/3b31d1f/packages/dispatchr/lib/DispatcherContext.js#L113), but this PR allows the `errorHandler` callback, if supplied, to be used in these cases as well.