### PR TITLE
Remove second setImmediate wrapper around callback during action exec…

### DIFF
--- a/packages/fluxible/docs/api/FluxibleContext.md
+++ b/packages/fluxible/docs/api/FluxibleContext.md
@@ -24,6 +24,7 @@ Creates a new context instance with the following parameters:
 
  * `options`: An object containing the context settings
  * `options.app`: Provides access to the application level functions and settings
+ * `options.optimizePromiseCallback`: Whether to optimize Promise callback. Defaults to `false`. `FluxibleContext` uses two setImmediate in [utils/callAction](https://github.com/yahoo/fluxible/blob/master/packages/fluxible/utils/callAction.js) when executing every action.  The second `setImmediate` wraps callback execution to make sure exceptions thrown during callback execution are not swallowed by Promise. This optimization eliminates the second `setImmediate` by catching errors caught by Promise and throwing it. This way, successful callback executions won't need this extra yielding because of the `setImmediate`.
 
 ### executeAction(action, payload, [done])
 

--- a/packages/fluxible/tests/unit/utils/promiseCallback.js
+++ b/packages/fluxible/tests/unit/utils/promiseCallback.js
@@ -1,0 +1,173 @@
+/* jshint newcap:false */
+/* global describe, it, beforeEach, before, after */
+
+'use strict';
+
+var expect = require('chai').expect;
+var promiseCallback = require('../../../utils/promiseCallback');
+
+var originalSetImmediate = global.setImmediate;
+var setImmediateFuncNames = [];
+
+function customSetImmediate() {
+    setImmediateFuncNames.push(arguments[0].name);
+    originalSetImmediate.apply(null, arguments);
+}
+
+describe('#promiseCallback', function () {
+    before(function() {
+        global.setImmediate = customSetImmediate;
+    });
+
+    beforeEach(function () {
+        setImmediateFuncNames = [];
+    });
+
+    after(function() {
+        global.setImmediate = originalSetImmediate;
+    });
+
+    describe('Regular execution', function () {
+        it('should call callback when promise resolves', function (done) {
+            var promise = new Promise(function (resolve, reject) {
+                resolve('resolved');
+            });
+            promiseCallback(promise, function callbackFn(err, result) {
+                expect(err).to.equal(null);
+                expect(result).to.equal('resolved');
+                expect(setImmediateFuncNames.length).to.equal(1);
+                expect(setImmediateFuncNames[0]).to.equal('callbackFn');
+                done();
+            });
+        });
+        it('should call callback when promise rejects', function (done) {
+            var promise = new Promise(function (resolve, reject) {
+                reject('rejected');
+            });
+            promiseCallback(promise, function callbackFn(err, result) {
+                expect(err).to.equal('rejected');
+                expect(result).to.equal(undefined);
+                expect(setImmediateFuncNames.length).to.equal(1);
+                expect(setImmediateFuncNames[0]).to.equal('callbackFn');
+                done();
+            });
+        });
+        it('should not throw error from success callback in same cycle', function (done) {
+            var promise = new Promise(function (resolve, reject) {
+                resolve('resolved');
+            });
+            var caughtError = null;
+            try {
+                promiseCallback(promise, function callbackFn(err, result) {
+                    throw new Error('callback error');
+                });
+            } catch (e) {
+                caughtError = e;
+            }
+            originalSetImmediate(function () {
+                expect(setImmediateFuncNames.length).to.equal(1);
+                expect(setImmediateFuncNames[0]).to.equal('callbackFn');
+                expect(caughtError).to.equal(null);
+                done();
+            });
+        });
+        it('should not throw error from failure callback in same cycle', function (done) {
+            var promise = new Promise(function callbackFn(resolve, reject) {
+                reject('rejected');
+            });
+            var caughtError = null;
+            try {
+                promiseCallback(promise, function callbackFn(err, result) {
+                    if (err) {
+                        throw new Error('callback error');
+                    }
+                });
+            } catch (e) {
+                caughtError = e;
+            }
+            originalSetImmediate(function () {
+                expect(setImmediateFuncNames.length).to.equal(1);
+                expect(setImmediateFuncNames[0]).to.equal('callbackFn');
+                expect(caughtError).to.equal(null);
+                done();
+            });
+        });
+    });
+
+    describe('Optimized execution', function () {
+        it('should call callback when promise resolves', function (done) {
+            var promise = new Promise(function (resolve, reject) {
+                resolve('resolved');
+            });
+            promiseCallback(promise, function (err, result) {
+                expect(err).to.equal(null);
+                expect(result).to.equal('resolved');
+                expect(setImmediateFuncNames.length).to.equal(0,
+                    'no setImmediate for successful callback');
+                done();
+            }, {
+                optimize: true
+            });
+        });
+        it('should call callback when promise rejects', function (done) {
+            var promise = new Promise(function (resolve, reject) {
+                reject('rejected');
+            });
+            promiseCallback(promise, function (err, result) {
+                expect(err).to.equal('rejected');
+                expect(result).to.equal(undefined);
+                expect(setImmediateFuncNames.length).to.equal(0,
+                    'no setImmediate for successful callback');
+                done();
+            }, {
+                optimize: true
+            });
+        });
+        it('should not throw error from success callback in same cycle', function (done) {
+            var promise = new Promise(function (resolve, reject) {
+                resolve('resolved');
+            });
+            var caughtError = null;
+            try {
+                promiseCallback(promise, function callbackFn(err, result) {
+                    throw new Error('callback error');
+                }, {
+                    optimize: true
+                });
+            } catch (e) {
+                caughtError = e;
+            }
+            originalSetImmediate(function () {
+                expect(setImmediateFuncNames.length).to.equal(1,
+                    '1 setImmediate for bad callback');
+                expect(setImmediateFuncNames[0]).to.equal('doNotSwallowError');
+                expect(caughtError).to.equal(null);
+                done();
+            });
+        });
+        it('should not throw error from failure callback in same cycle', function (done) {
+            var promise = new Promise(function (resolve, reject) {
+                reject('rejected');
+            });
+            var caughtError = null;
+            try {
+                promiseCallback(promise, function callbackFn(err, result) {
+                    if (err) {
+                        throw new Error('callback error');
+                    }
+                }, {
+                    optimize: true
+                });
+            } catch (e) {
+                caughtError = e;
+            }
+            originalSetImmediate(function () {
+                expect(setImmediateFuncNames.length).to.equal(1,
+                    '1 setImmediate for bad callback');
+                expect(setImmediateFuncNames[0]).to.equal('doNotSwallowError');
+                expect(caughtError).to.equal(null);
+                done();
+            });
+        });
+    });
+});

--- a/packages/fluxible/utils/callAction.js
+++ b/packages/fluxible/utils/callAction.js
@@ -5,6 +5,7 @@
 /* global Promise */
 'use strict';
 var isPromise = require('is-promise');
+var promiseCallback = require('./promiseCallback');
 require('setimmediate');
 
 /**
@@ -36,14 +37,7 @@ function callAction (actionContext, action, payload, done) {
     });
 
     if (done) {
-        executeActionPromise
-            .then(function(result) {
-                // Ensures that errors in callback are not swallowed by promise
-                setImmediate(done, null, result);
-            }, function (err) {
-                // Ensures that errors in callback are not swallowed by promise
-                setImmediate(done, err);
-            });
+        promiseCallback(executeActionPromise, done, {optimize: actionContext.optimizePromiseCallback});
     }
 
     return executeActionPromise;

--- a/packages/fluxible/utils/promiseCallback.js
+++ b/packages/fluxible/utils/promiseCallback.js
@@ -1,0 +1,41 @@
+'use strict';
+
+require('setimmediate');
+
+/**
+ * Execute a callback function when promise resolves or rejects
+ * @method promiseCallback
+ * @param {Promise} promise The promise
+ * @param {Function} callbackFn The callback function
+ * @param {Object} options The options object
+ * @param {Boolean} options.optimize Whether to optimize
+ * @return {void}
+ */
+function promiseCallback (promise, callbackFn, options) {
+    if (!promise || typeof callbackFn !== 'function') {
+        return;
+    }
+
+    if (options && options.optimize) {
+        promise.then(function (result) {
+            callbackFn(null, result);
+        }, callbackFn)
+        ['catch'](function (err) {
+            // Ensures that thrown errors in the `callbackFn()` callback above are
+            // not swallowed by promise
+            setImmediate(function doNotSwallowError() {
+                throw err;
+            });
+        });
+    } else {
+        promise.then(function(result) {
+            // Ensures that errors in callback are not swallowed by promise
+            setImmediate(callbackFn, null, result);
+        }, function (err) {
+            // Ensures that errors in callback are not swallowed by promise
+            setImmediate(callbackFn, err);
+        });
+    }
+};
+
+module.exports = promiseCallback;


### PR DESCRIPTION
…ution, for less artifial yielding for most of the normal cases where callback function executes successfully with no exception.

Based on https://github.com/yahoo/fluxible/pull/518 and the differences are:

* This is a less ambitious version of https://github.com/yahoo/fluxible/pull/518, which we had some regression while testing an internal app.  The goal is the same, removing one setImmediate for normal (no-error) action execution.
* The optimization is behind a config `optimizePromiseCallback` (of `FluxibleContext` constructor) to ensure we don't accidentally break other apps using Fluxible.

@redonkulus @mridgway @kfay @ericf
