### PR TITLE
Switch to the prop-types package

### DIFF
--- a/packages/fluxible-plugin-devtools/package.json
+++ b/packages/fluxible-plugin-devtools/package.json
@@ -17,7 +17,11 @@
     "prepublish": "npm run dist"
   },
   "dependencies": {
-    "debug": "^2.0.0"
+    "debug": "^2.0.0",
+    "prop-types": "^15.5.8"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0 || ^15.0.0-rc.1"
   },
   "author": "Rajiv Tirumalareddy <rajivtirum@yahoo-inc.com>",
   "contributors": [],

--- a/packages/fluxible-plugin-devtools/package.json
+++ b/packages/fluxible-plugin-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluxible-plugin-devtools",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A plugin for Fluxible applications to provide debugging information",
   "main": "index.js",
   "repository": {

--- a/packages/fluxible-plugin-devtools/src/components/Actions.jsx
+++ b/packages/fluxible-plugin-devtools/src/components/Actions.jsx
@@ -2,12 +2,13 @@
  * Copyright 2016, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
+import PropTypes from 'prop-types';
 import React from 'react';
 import ActionTree from './ActionTree';
 
 export default class Actions extends React.Component {
     static contextTypes = {
-        devtools: React.PropTypes.object
+        devtools: PropTypes.object
     }
 
     render() {


### PR DESCRIPTION
@Vijar @redonkulus @lingyan 

This removes a react 15.5 warning about `PropTypes` by switching to the `prop-types` package rather than using `React.PropTypes`