### PR TITLE
Move create-react-class to devDeps

### DIFF
--- a/packages/fluxible-addons-react/package.json
+++ b/packages/fluxible-addons-react/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "hoist-non-react-statics": "^1.0.4",
     "inherits": "^2.0.1",
-    "create-react-class": "^15.5.1",
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {
@@ -24,6 +23,7 @@
     "react-dom": "^0.14.0 || ^15.0.0-rc.1"
   },
   "devDependencies": {
+    "create-react-class": "^15.5.1",
     "fluxible": ">=1.0.0",
     "react": "^15.0.0-rc.1",
     "react-dom": "^15.0.0-rc.1"


### PR DESCRIPTION
@lingyan @snyamathi @kfay 

Half fixes https://github.com/yahoo/fluxible/issues/546

This is only used for testing, no point in making people install it.