### PR TITLE
Remember the referrer url in history state object

### DIFF
--- a/packages/fluxible-router/lib/History.js
+++ b/packages/fluxible-router/lib/History.js
@@ -102,7 +102,9 @@ History.prototype = {
             url = isUndefined(url) ? win.location.href : url;
 
             // remember the original url in state, so that it can be used by getUrl()
-            var _state = Object.assign({origUrl: url}, state);
+            // remember the referrer url in state, so that it can be used for back navigations
+            var _state = Object.assign({origUrl: url, referrerUrl: win.location.href}, state);
+
             try {
                 win.history.pushState(_state, title, url);
             } catch (_) {

--- a/packages/fluxible-router/package.json
+++ b/packages/fluxible-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluxible-router",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Routing for Fluxible applications",
   "main": "index.js",
   "repository": {

--- a/packages/fluxible-router/tests/unit/lib/History-test.js
+++ b/packages/fluxible-router/tests/unit/lib/History-test.js
@@ -202,30 +202,30 @@ describe('History', function () {
             var history = new History({win: win});
 
             history.pushState({foo: 'bar'});
-            expect(testResult.pushState.state).to.eql({origUrl: '/currentUrl', foo: 'bar'});
+            expect(testResult.pushState.state).to.eql({origUrl: '/currentUrl', referrerUrl: '/currentUrl', foo: 'bar'});
             expect(testResult.pushState.title).to.equal('current title');
             expect(testResult.pushState.url).to.equal('/currentUrl');
 
             history.pushState({foo: 'bar'}, 't');
-            expect(testResult.pushState.state).to.eql({origUrl: '/currentUrl', foo: 'bar'});
+            expect(testResult.pushState.state).to.eql({origUrl: '/currentUrl', referrerUrl: '/currentUrl', foo: 'bar'});
             expect(testResult.pushState.title).to.equal('t');
             expect(testResult.pushState.url).to.equal('/currentUrl');
 
             history.pushState({foo: 'bar'}, 't', '/url');
-            expect(testResult.pushState.state).to.eql({origUrl: '/url', foo: 'bar'});
+            expect(testResult.pushState.state).to.eql({origUrl: '/url', referrerUrl: '/currentUrl', foo: 'bar'});
             expect(testResult.pushState.title).to.equal('t');
             expect(testResult.pushState.url).to.equal('/url');
             expect(windowMock.HTML5.document.title).to.equal('t');
 
             history.pushState({foo: 'bar'}, 'tt', '/url?a=b&x=y');
-            expect(testResult.pushState.state).to.eql({origUrl: '/url?a=b&x=y', foo: 'bar'});
+            expect(testResult.pushState.state).to.eql({origUrl: '/url?a=b&x=y', referrerUrl: '/currentUrl', foo: 'bar'});
             expect(testResult.pushState.title).to.equal('tt');
             expect(testResult.pushState.url).to.equal('/url?a=b&x=y');
             expect(windowMock.HTML5.document.title).to.equal('tt');
 
             var unicodeUrl = '/post/128097060420/2015-fno-vogue全球購物夜-眾藝人名人共襄盛舉';
             history.pushState({foo: 'bar'}, 'tt', unicodeUrl);
-            expect(testResult.pushState.state).to.eql({origUrl: unicodeUrl, foo: 'bar'});
+            expect(testResult.pushState.state).to.eql({origUrl: unicodeUrl, referrerUrl: '/currentUrl', foo: 'bar'});
             expect(testResult.pushState.title).to.equal('tt');
             expect(testResult.pushState.url).to.equal(unicodeUrl);
             expect(windowMock.HTML5.document.title).to.equal('tt');
@@ -242,17 +242,17 @@ describe('History', function () {
             var history = new History({win: win});
 
             history.pushState({foo: 'bar'});
-            expect(testResult.pushState.state).to.eql({origUrl: '/currentUrl', foo: 'bar'});
+            expect(testResult.pushState.state).to.eql({origUrl: '/currentUrl', referrerUrl: '/currentUrl', foo: 'bar'});
             expect(testResult.pushState.title).to.equal('current title');
             expect(testResult.pushState.url).to.equal('/currentUrl');
 
             history.pushState({foo: 'bar'}, 't');
-            expect(testResult.pushState.state).to.eql({origUrl: '/currentUrl', foo: 'bar'});
+            expect(testResult.pushState.state).to.eql({origUrl: '/currentUrl', referrerUrl: '/currentUrl', foo: 'bar'});
             expect(testResult.pushState.title).to.equal('t');
             expect(testResult.pushState.url).to.equal('/currentUrl');
 
             history.pushState({foo: 'bar'}, 't', '/url');
-            expect(testResult.pushState.state).to.eql({origUrl: '/url', foo: 'bar'});
+            expect(testResult.pushState.state).to.eql({origUrl: '/url', referrerUrl: '/currentUrl', foo: 'bar'});
             expect(testResult.pushState.title).to.equal('t');
             expect(testResult.pushState.url).to.equal('/url');
         });


### PR DESCRIPTION
## Reviewers
@lingyan @redonkulus 

## Goal
Remember the referrer url in the history. This honors the correct referrer for all client side navigations and particularly helpful for handling back button clicks during page navigation correctly. 

_Example:
Page:A ( origUrl: /A.html ) -> Page:B ( origUrl: /B.html, referrerUrl: https://www.example.com/A.html ) -> C.html ( origUrl: /C.html, referrerUrl: https://www.example.com/B.html )_

The history object would look something like this now:
```
history = {
    length: 3,
    scrollRestoration: manual,
    state: {
        origUrl: "abc.html",
        referrerUrl: "http://www.xyz.html",
        scroll: {
            x: 0,
            y: 0
        }
    }
}
```
    