### PR TITLE
Update hoist-non-react-statics to the latest version

### DIFF
--- a/packages/fluxible-addons-react/package.json
+++ b/packages/fluxible-addons-react/package.json
@@ -13,7 +13,7 @@
     "lint": "../../node_modules/.bin/eslint *.js tests/"
   },
   "dependencies": {
-    "hoist-non-react-statics": "^1.0.4",
+    "hoist-non-react-statics": "^2.5.0",
     "inherits": "^2.0.1",
     "prop-types": "^15.5.8"
   },

--- a/packages/fluxible-router/package.json
+++ b/packages/fluxible-router/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "debug": "^2.0.0",
     "fluxible-addons-react": "^0.2.0",
-    "hoist-non-react-statics": "^1.0.4",
+    "hoist-non-react-statics": "^2.5.0",
     "inherits": "^2.0.1",
     "prop-types": "^15.5.8",
     "routr": "^2.0.0"


### PR DESCRIPTION
@yahoo/team-fluxible @mridgway 

This updates hoist-non-react-statics to the latest version compatible with react 16.3 https://github.com/mridgway/hoist-non-react-statics#compatible-react-versions