### PR TITLE
remember prevNavigate

### DIFF
--- a/packages/fluxible-router/docs/api/RouteStore.md
+++ b/packages/fluxible-router/docs/api/RouteStore.md
@@ -2,7 +2,7 @@
 
 The `RouteStore` maintains the routes and handles the route matching logic. The `RouteStore` listens for `NAVIGATE_START` and `RECEIVE_ROUTES` events.
 
-When a `NAVIGATE_START` event is heard we attempt to match the route provided by the `payload.url`. If a match is made we update the `currentRoute` with the matched route. We also set the `currentNavigate` property to be the original `payload`. You typically access these properties via `getCurrentRoute()` and `getCurrentNavigate()`.
+When a `NAVIGATE_START` event is heard we attempt to match the route provided by the `payload.url`. If a match is made we update the `currentRoute` with the matched route. We also set the `currentNavigate` property to be the original `payload`. You typically access these properties via `getCurrentRoute()` and `getCurrentNavigate()`. In addition, the previous navigation object will be saved in the store, which contains information about the route before this navigation. The previous navigate object is accessible through `getPrevNavigate()`.
 
 When a `RECEIVE_ROUTES` event is heard we merge the current routes (if any) with those found in the `payload` object. We then nullify the current router instance so it's re-created with the most up-to-date routes next time it's needed.
 

--- a/packages/fluxible-router/src/lib/RouteStore.js
+++ b/packages/fluxible-router/src/lib/RouteStore.js
@@ -19,6 +19,7 @@ var RouteStore = createStore({
         this._routes = null;
         this._router = null;
         this._currentNavigate = null;
+        this._prevNavigate = null;
     },
     _handleNavigateStart: function (navigate) {
         var currentRoute = this._currentNavigate && this._currentNavigate.route;
@@ -31,6 +32,8 @@ var RouteStore = createStore({
         if (this._areEqual(matchedRoute, currentRoute)) {
             matchedRoute = currentRoute;
         }
+
+        this._prevNavigate = this._currentNavigate;
 
         this._currentNavigate = Object.assign({}, navigate, {
             route: matchedRoute,
@@ -115,6 +118,9 @@ var RouteStore = createStore({
     getCurrentNavigate: function () {
         return this._currentNavigate;
     },
+    getPrevNavigate: function () {
+        return this._prevNavigate;
+    },
     getCurrentNavigateError: function () {
         return this._currentNavigate && this._currentNavigate.error;
     },
@@ -137,12 +143,16 @@ var RouteStore = createStore({
         return this._currentNavigate && this._currentNavigate.url === href;
     },
     dehydrate: function () {
+        // no need to dehydrate this._prevNavigate, because it will always
+        // be null on server request
         return {
             currentNavigate: this._currentNavigate,
             routes: this._routes
         };
     },
     rehydrate: function (state) {
+        // no need to rehydrate this._prevNavigate, since it is not being
+        // dehydrated
         this._routes = state.routes;
         if (this._routes) {
             this._router = null;

--- a/packages/fluxible-router/tests/unit/lib/NavLink-test.js
+++ b/packages/fluxible-router/tests/unit/lib/NavLink-test.js
@@ -497,6 +497,7 @@ describe('NavLink', function () {
 
         it('should throw if context not available', function () {
             expect(function () {
+                // eslint-disable-next-line no-useless-catch
                 try{
                     ReactTestUtils.renderIntoDocument(
                         <NavLink href='/foo' followLink={false} />

--- a/packages/fluxible-router/tests/unit/lib/RouteStore-test.js
+++ b/packages/fluxible-router/tests/unit/lib/RouteStore-test.js
@@ -234,4 +234,47 @@ describe('RouteStore', function () {
         });
     });
 
+    it('Prev Navigate', function () {
+        var routeStore = new RouteStore();
+        var routes = {
+            foo: {
+                path: '/foo',
+                method: 'get'
+            },
+            bar: {
+                path: '/bar',
+                method: 'post'
+            }
+        };
+        routeStore._handleReceiveRoutes(routes);
+        routeStore._handleNavigateStart({
+            url: '/foo',
+            method: 'get'
+        });
+        expect(routeStore.getCurrentNavigate().url).to.equal('/foo');
+        expect(routeStore.getCurrentNavigate().method).to.equal('get');
+        expect(routeStore.getPrevNavigate()).to.equal(null);
+        routeStore._handleNavigateSuccess({
+            transactionId: 'first',
+            route: {
+                url: '/foo',
+                method: 'get'
+            }
+        });
+        routeStore._handleNavigateStart({
+            url: '/bar',
+            method: 'get'
+        });
+        expect(routeStore.getCurrentNavigate().url).to.equal('/bar');
+        expect(routeStore.getCurrentNavigate().method).to.equal('get');
+        expect(routeStore.getPrevNavigate().url).to.equal('/foo');
+        expect(routeStore.getPrevNavigate().method).to.equal('get');
+
+        var state = routeStore.dehydrate();
+        expect(state).to.be.an('object');
+        expect(state.currentNavigate.url).to.equal('/bar');
+        expect(state.currentNavigate.method).to.equal('get');
+        expect(state.prevNavigate).to.equal(undefined);
+        expect(state.routes).to.deep.equal(routes);
+    });
 });


### PR DESCRIPTION
We have a use case, where previous navigate object is needed to render a component (a **Back** link/button in this specific case).   We could've done this in application's own store listening to NAVIGATE_* events, but thought adding this functionality here will also benefit other Fluxible users.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
