### PR TITLE
[fluxible-router] Return failure when no action can be resolved (#616)

### DIFF
--- a/packages/fluxible-router/lib/navigateAction.js
+++ b/packages/fluxible-router/lib/navigateAction.js
@@ -42,14 +42,25 @@ function navigateAction (context, payload, done) {
     }
 
     var action = route.action;
+    if (!action) {
+        debug('route has no action, dispatching without calling action');
+        context.dispatch('NAVIGATE_SUCCESS', completionPayload);
+        done();
+        return;
+    }
+
     if ('string' === typeof action && context.getAction) {
         action = context.getAction(action);
     }
 
     if (!action || 'function' !== typeof action) {
-        debug('route has no action, dispatching without calling action');
-        context.dispatch('NAVIGATE_SUCCESS', completionPayload);
-        done();
+        debug('action cannot be resolved');
+        completionPayload.error = {
+            statusCode: 500,
+            message: 'Action for ' + payload.url + ' can not be resolved'
+        };
+        context.dispatch('NAVIGATE_FAILURE', completionPayload);
+        done(completionPayload.error);
         return;
     }
 

--- a/packages/fluxible-router/tests/unit/lib/navigateAction-test.js
+++ b/packages/fluxible-router/tests/unit/lib/navigateAction-test.js
@@ -44,6 +44,11 @@ describe('navigateAction', function () {
             action: function (context, payload, done) {
                 done();
             }
+        },
+        noMatchedAction: {
+            method: 'get',
+            path: '/noMatchedAction',
+            action: 'noMatchedAction'
         }
     };
     var fooAction = function (context, payload, done) {
@@ -201,6 +206,22 @@ describe('navigateAction', function () {
             expect(mockContext.dispatchCalls[0].payload.url).to.equal('/post');
             expect(mockContext.dispatchCalls[1].name).to.equal('NAVIGATE_SUCCESS');
             expect(mockContext.dispatchCalls[1].payload.url).to.equal('/post');
+            done();
+        });
+    });
+
+    it('should dispatch faliure if action can\'t be resolved', function (done) {
+        navigateAction(mockContext, {
+            url: '/noMatchedAction',
+            method: 'get'
+        }, function (err) {
+            expect(err.statusCode).to.equal(500);
+            expect(err.message).to.equal('Action for /noMatchedAction can not be resolved');
+            expect(mockContext.dispatchCalls.length).to.equal(2);
+            expect(mockContext.dispatchCalls[0].name).to.equal('NAVIGATE_START');
+            expect(mockContext.dispatchCalls[0].payload.url).to.equal('/noMatchedAction');
+            expect(mockContext.dispatchCalls[1].name).to.equal('NAVIGATE_FAILURE');
+            expect(mockContext.dispatchCalls[1].payload.url).to.equal('/noMatchedAction');
             done();
         });
     });


### PR DESCRIPTION
Backport for #615

* [fluxible-router] Return failure when no action can be resolved

Co-authored-by: tom76kimo <tom76kimo@verizonmedia.com>
Co-authored-by: Seth Bertalotto <seth@bertalotto.net>


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
