### PR TITLE
Refactored fluxible-addons-react to use ES2015+ features

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,10 +51,6 @@
     "sinon": "^9.0.1",
     "yargs": "^16.0.0"
   },
-  "devEngines": {
-    "node": "4.x || 5.x || 6.x",
-    "npm": "2.x || 3.x"
-  },
   "pre-commit": [
     "dev:lint",
     "dev:test"

--- a/packages/fluxible-addons-react/package.json
+++ b/packages/fluxible-addons-react/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "hoist-non-react-statics": "^3.3.2",
-    "inherits": "^2.0.4",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/packages/fluxible-addons-react/src/FluxibleComponent.js
+++ b/packages/fluxible-addons-react/src/FluxibleComponent.js
@@ -4,42 +4,32 @@
  */
 'use strict';
 
-var React = require('react');
-var PropTypes = require('prop-types');
-var inherits = require('inherits');
+const React = require('react');
+const PropTypes = require('prop-types');
 
-function FluxibleComponent(props, context) {
-    React.Component.apply(this, arguments);
-}
-
-inherits(FluxibleComponent, React.Component);
-
-FluxibleComponent.displayName = 'FluxibleComponent';
-FluxibleComponent.propTypes = {
-    context: PropTypes.object.isRequired
-};
-FluxibleComponent.childContextTypes = {
-    executeAction: PropTypes.func.isRequired,
-    getStore: PropTypes.func.isRequired
-};
-
-Object.assign(FluxibleComponent.prototype, {
-    /**
-     * Provides the current context as a child context
-     * @method getChildContext
-     */
-    getChildContext: function () {
+class FluxibleComponent extends React.Component {
+    getChildContext() {
         return {
             getStore: this.props.context.getStore,
             executeAction: this.props.context.executeAction
         };
-    },
+    }
 
-    render: function () {
+    render() {
         return React.cloneElement(this.props.children, {
             context: this.props.context
         });
     }
-});
+}
+
+FluxibleComponent.propTypes = {
+    children: PropTypes.node.isRequired,
+    context: PropTypes.object.isRequired
+};
+
+FluxibleComponent.childContextTypes = {
+    executeAction: PropTypes.func.isRequired,
+    getStore: PropTypes.func.isRequired
+};
 
 module.exports = FluxibleComponent;

--- a/packages/fluxible-addons-react/src/batchedUpdatePlugin.js
+++ b/packages/fluxible-addons-react/src/batchedUpdatePlugin.js
@@ -3,35 +3,26 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 'use strict';
-var batchedUpdates = require('react-dom').unstable_batchedUpdates;
+const { unstable_batchedUpdates } = require('react-dom');
 
-module.exports = function createBatchedUpdatePlugin(options) {
+function createBatchedUpdatePlugin() {
     /**
      * @class BatchedUpdatePlugin
      */
     return {
         name: 'BatchedUpdatePlugin',
-        /**
-         * Called to plug the FluxContext
-         * @method plugContext
-         * @returns {Object}
-         */
-        plugContext: function plugContext() {
+
+        plugContext() {
             return {
-                /**
-                 * Provides full access to the router in the action context
-                 * @param {Object} actionContext
-                 */
-                plugActionContext: function plugActionContext(actionContext) {
-                    var oldDispatch = actionContext.dispatch;
-                    actionContext.dispatch = function () {
-                        var args = arguments;
-                        batchedUpdates(function () {
-                            oldDispatch.apply(actionContext, args);
-                        });
+                plugActionContext(actionContext) {
+                    const oldDispatch = actionContext.dispatch;
+                    actionContext.dispatch = (...args) => {
+                        unstable_batchedUpdates(() => { oldDispatch.apply(actionContext, args); });
                     };
                 }
             };
         }
     };
-};
+}
+
+module.exports = createBatchedUpdatePlugin;

--- a/packages/fluxible-addons-react/src/createElementWithContext.js
+++ b/packages/fluxible-addons-react/src/createElementWithContext.js
@@ -4,8 +4,8 @@
  */
 'use strict';
 
-var React = require('react');
-var FluxibleComponent = require('./FluxibleComponent');
+const React = require('react');
+const FluxibleComponent = require('./FluxibleComponent');
 
 /**
  * Creates an instance of the app level component with given props and a proper component
@@ -14,19 +14,23 @@ var FluxibleComponent = require('./FluxibleComponent');
  * @param {Object} props
  * @return {ReactElement}
  */
-module.exports = function createElement(fluxibleContext, props) {
-    var Component = fluxibleContext.getComponent();
+function createElementWithContext(fluxibleContext, props) {
+    const Component = fluxibleContext.getComponent();
     if (!Component) {
-        throw new Error('A top-level component was not passed to the Fluxible' +
-            ' constructor.');
+        throw new Error('A top-level component was not passed to the Fluxible constructor.');
     }
-    if (Component.displayName && -1 !== Component.displayName.indexOf('contextProvider')) {
-        return React.createElement(Component, Object.assign({}, {
-            context: fluxibleContext.getComponentContext()
-        }, props));
+    if (Component.displayName && Component.displayName.includes('contextProvider')) {
+        return React.createElement(
+            Component,
+            {context: fluxibleContext.getComponentContext(), ...props},
+        );
     }
-    var componentInstance = React.createElement(Component, props);
-    return React.createElement(FluxibleComponent, {
-        context: fluxibleContext.getComponentContext()
-    }, componentInstance);
-};
+    const componentInstance = React.createElement(Component, props);
+    return React.createElement(
+        FluxibleComponent,
+        {context: fluxibleContext.getComponentContext()},
+        componentInstance
+    );
+}
+
+module.exports = createElementWithContext;

--- a/packages/fluxible-addons-react/src/provideContext.js
+++ b/packages/fluxible-addons-react/src/provideContext.js
@@ -4,63 +4,15 @@
  */
 'use strict';
 
-var React = require('react');
-var PropTypes = require('prop-types');
-var hoistNonReactStatics = require('hoist-non-react-statics');
-var inherits = require('inherits');
-
-function createComponent(Component, customContextTypes) {
-    var componentName = Component.displayName || Component.name || 'Component';
-    var childContextTypes = Object.assign({
-        executeAction: PropTypes.func.isRequired,
-        getStore: PropTypes.func.isRequired
-    }, customContextTypes || {});
-
-    function ContextProvider(props, context) {
-        React.Component.apply(this, arguments);
-        this.wrappedElementRef = React.createRef();
-    }
-
-    inherits(ContextProvider, React.Component);
-
-    ContextProvider.displayName = 'contextProvider(' + componentName + ')';
-    ContextProvider.propTypes = {
-        context: PropTypes.object.isRequired
-    };
-    ContextProvider.childContextTypes = childContextTypes;
-
-    Object.assign(ContextProvider.prototype, {
-        getChildContext: function () {
-            var childContext = {
-                executeAction: this.props.context.executeAction,
-                getStore: this.props.context.getStore
-            };
-            if (customContextTypes) {
-                Object.keys(customContextTypes).forEach(function (key) {
-                    childContext[key] = this.props.context[key];
-                }, this);
-            }
-            return childContext;
-        },
-
-        render: function () {
-            var props = (Component.prototype && Component.prototype.isReactComponent)
-                ? {ref: this.wrappedElementRef}
-                : null;
-            return React.createElement(Component, Object.assign({}, this.props, props));
-        }
-    });
-
-    hoistNonReactStatics(ContextProvider, Component);
-
-    return ContextProvider;
-}
+const React = require('react');
+const PropTypes = require('prop-types');
+const hoistNonReactStatics = require('hoist-non-react-statics');
 
 /**
  * Provides context prop to all children as React context
  *
  * Example:
- *   var WrappedComponent = provideContext(Component, {
+ *   const WrappedComponent = provideContext(Component, {
  *       foo: PropTypes.string
  *   });
  *
@@ -69,6 +21,49 @@ function createComponent(Component, customContextTypes) {
  * @param {object} customContextTypes Custom contextTypes to add
  * @returns {React.Component} or {Function} if using decorator pattern
  */
-module.exports = function provideContext(Component, customContextTypes) {
-    return createComponent.apply(null, arguments);
-};
+function provideContext(Component, customContextTypes) {
+    class ContextProvider extends React.Component {
+        constructor(props) {
+            super(props);
+            this.wrappedElementRef = React.createRef();
+        }
+
+        getChildContext() {
+            const childContext = {
+                executeAction: this.props.context.executeAction,
+                getStore: this.props.context.getStore
+            };
+            if (customContextTypes) {
+                Object.keys(customContextTypes).forEach(key => {
+                    childContext[key] = this.props.context[key];
+                });
+            }
+            return childContext;
+        }
+
+        render() {
+            const props = (Component.prototype && Component.prototype.isReactComponent)
+                ? {ref: this.wrappedElementRef}
+                : null;
+            return React.createElement(Component, {...this.props, ...props});
+        }
+    }
+
+    ContextProvider.childContextTypes = {
+        executeAction: PropTypes.func.isRequired,
+        getStore: PropTypes.func.isRequired,
+        ...customContextTypes
+    };
+
+    ContextProvider.propTypes = {
+        context: PropTypes.object.isRequired
+    };
+
+    ContextProvider.displayName = `contextProvider(${Component.displayName || Component.name || 'Component'})`;
+
+    hoistNonReactStatics(ContextProvider, Component);
+
+    return ContextProvider;
+}
+
+module.exports = provideContext;


### PR DESCRIPTION
So, before tackling #636, #587, #584 and introduce any breaking changes, I thought it would be good to make fluxible react components to look like modern react components. So I basically just converted all components to be ES2015 classes.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
