### PR TITLE
fluxible: remove react unsafe methods

### DIFF
--- a/packages/fluxible/package.json
+++ b/packages/fluxible/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluxible",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A pluggable container for isomorphic flux applications",
   "main": "index.js",
   "repository": {

--- a/packages/fluxible/utils/deprecateComponent.js
+++ b/packages/fluxible/utils/deprecateComponent.js
@@ -17,7 +17,7 @@ module.exports = function deprecateComponent(Component, warningMessage) {
     var DeprecationComponent = React.createClass({
         displayName: 'DeprecationComponent',
 
-        componentWillMount: function () {
+        componentDidMount: function () {
             console.warn(warningMessage);
         },
 


### PR DESCRIPTION
Removing them from `fluxible-react-addons` is a little bit tricky since `getDerivedStateFromProps` is a static method so we wouldn't have access to the context. But `fluxible` package also had a component with the deprecated method that was easy to replace. So I'm delivering it now because I will need more time in the other one.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
