### PR TITLE
fluxible-addons-react: remove depreacted react methods

### DIFF
--- a/packages/fluxible-addons-react/package.json
+++ b/packages/fluxible-addons-react/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "hoist-non-react-statics": "^3.0.1",
     "inherits": "^2.0.1",
+    "nanoid": "^3.1.12",
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {

--- a/packages/fluxible-addons-react/package.json
+++ b/packages/fluxible-addons-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluxible-addons-react",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "Fluxible addons for use with React",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This is related to #587 and #636. Here I'm just solving the issue for fluxible-addons-react.

This one was a tricky. We can't use `getDerivedStateFromProps` since it is static and we need to have access to `this.context`. 

The solution that I found was to use `componentDidUpdate` since react assures that user will not see the "in between" state. But since `setState` triggers `componentDidMount`, we needed a condition to prevent an infinite recursion during an update. 

So I added a key in the state so we have something as a reference if the component was already updated or not. This key is invalidated whenever an update occurs. The key is random generated by nanoid. I opted for nanoid since it is even smaller than the react polyfill we were planning to use.

I haven't worked on fluxible-router yet since I would like to know first if this approach is valid or not.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
