### PR TITLE
support RESET_ROUTES event

### DIFF
--- a/packages/fluxible-router/docs/api/RouteStore.md
+++ b/packages/fluxible-router/docs/api/RouteStore.md
@@ -1,10 +1,12 @@
 # API: `RouteStore`
 
-The `RouteStore` maintains the routes and handles the route matching logic. The `RouteStore` listens for `NAVIGATE_START` and `RECEIVE_ROUTES` events.
+The `RouteStore` maintains the routes and handles the route matching logic. The `RouteStore` listens for `NAVIGATE_START`, `NAVIGATE_SUCCESS`, `NAVIGATE_FAILURE`, `RECEIVE_ROUTES`, and `RESET_ROUTES` events.
 
 When a `NAVIGATE_START` event is heard we attempt to match the route provided by the `payload.url`. If a match is made we update the `currentRoute` with the matched route. We also set the `currentNavigate` property to be the original `payload`. You typically access these properties via `getCurrentRoute()` and `getCurrentNavigate()`. In addition, the previous navigation object will be saved in the store, which contains information about the route before this navigation. The previous navigate object is accessible through `getPrevNavigate()`.
 
 When a `RECEIVE_ROUTES` event is heard we merge the current routes (if any) with those found in the `payload` object. We then nullify the current router instance so it's re-created with the most up-to-date routes next time it's needed.
+
+Note that if multiple `RECEIVE_ROUTES` events are received, the event payloads of these events are merged together in the receiving order.  This could make it hard to delete routes.  If needed, you can also dispatch a `RESET_ROUTES` event, which will completely overwrite the routes with the event payload.  Similar to `RECEIVE_ROUTES`, we will nullify the current router instance so it's re-created with the most up-to-date routes next time it's needed.
 
 ## Quick Start
 

--- a/packages/fluxible-router/src/lib/RouteStore.js
+++ b/packages/fluxible-router/src/lib/RouteStore.js
@@ -13,7 +13,8 @@ var RouteStore = createStore({
         'NAVIGATE_START': '_handleNavigateStart',
         'NAVIGATE_SUCCESS': '_handleNavigateSuccess',
         'NAVIGATE_FAILURE': '_handleNavigateFailure',
-        'RECEIVE_ROUTES': '_handleReceiveRoutes'
+        'RECEIVE_ROUTES': '_handleReceiveRoutes',
+        'RESET_ROUTES': '_handleResetRoutes'
     },
     initialize: function () {
         this._routes = null;
@@ -79,6 +80,11 @@ var RouteStore = createStore({
     _handleReceiveRoutes: function (payload) {
         this._routes = Object.assign({}, this._routes || {}, payload);
         // Reset the router so that it is recreated next time it's needed
+        this._router = null;
+        this.emitChange();
+    },
+    _handleResetRoutes: function (payload) {
+        this._routes = payload || {};
         this._router = null;
         this.emitChange();
     },

--- a/packages/fluxible-router/tests/unit/lib/RouteStore-test.js
+++ b/packages/fluxible-router/tests/unit/lib/RouteStore-test.js
@@ -277,4 +277,33 @@ describe('RouteStore', function () {
         expect(state.prevNavigate).to.equal(undefined);
         expect(state.routes).to.deep.equal(routes);
     });
+
+    it('reset routes', function () {
+        var routeStore = new RouteStore();
+        var routes = {
+            foo: {
+                path: '/foo',
+                method: 'get'
+            },
+            bar: {
+                path: '/bar',
+                method: 'post'
+            }
+        };
+        routeStore._handleReceiveRoutes(routes);
+        var state = routeStore.dehydrate();
+        expect(state).to.be.an('object');
+        expect(state.routes).to.deep.equal(routes);
+
+        var newRoutes = {
+            baz: {
+                path: '/baz',
+                method: 'get'
+            }
+        };
+        routeStore._handleResetRoutes(newRoutes);
+        var newState = routeStore.dehydrate();
+        expect(newState).to.be.an('object');
+        expect(newState.routes).to.deep.equal(newRoutes);
+    });
 });


### PR DESCRIPTION
Add support for RESET_ROUTES event, to make it easier to delete routes.  Please see the doc update in the PR for more details.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
