### PR TITLE
Update README to point to correct lerna url

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ This software is free to use under the Yahoo Inc. BSD license.
 See the [LICENSE file] for license text and copyright information.
 
 [LICENSE file]: https://github.com/yahoo/fluxible/blob/master/LICENSE.md
-[Lerna]: https://lernajs.io/
+[Lerna]: https://lerna.js.org/


### PR DESCRIPTION
I had never heard of Lerna before, I clicked on the link it was broken so I found the project page for lerna and updated to https://lerna.js.org/


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.


