### PR TITLE
fluxible-router: update fluxible-addons-react to latest version

### DIFF
--- a/packages/fluxible-router/package.json
+++ b/packages/fluxible-router/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "debug": "^2.0.0",
-    "fluxible-addons-react": "^0.2.16",
+    "fluxible-addons-react": "^1.0.0-beta.0",
     "hoist-non-react-statics": "^3.0.1",
     "inherits": "^2.0.1",
     "prop-types": "^15.5.8",


### PR DESCRIPTION
@redonkulus I forgot to update fluxible-addons-react version on fluxible-router. So, currently, fluxible-router doesn't work with the old addons neither with the new one. 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
