### PR TITLE
fluxible-addonts-react: add imports section in UPGRADE documentation

### DIFF
--- a/packages/fluxible-addons-react/UPGRADE.md
+++ b/packages/fluxible-addons-react/UPGRADE.md
@@ -2,6 +2,25 @@
 
 ## From 0.2.x to 1.0.0
 
+### imports
+
+Since the published version is a babel transpiled code that resides on a 
+dist folder, imports like `fluxible-addons-react/connectToStores` don't work anymore.
+
+**Before**
+
+```javascript
+import connectToStores from 'fluxible-addonts-react/connectToStores';
+import provideContext from 'fluxible-addonts-react/provideContext';
+// ...
+```
+
+**After**
+
+```javascript
+import { connectToStores, provideContext } from 'fluxible-addonts-react';
+```
+
 ### provideContext
 
 `provideContext(Component, customContextTypes)` -> `provideContext(Component, plugins)`


### PR DESCRIPTION
@redonkulus after migrating the site to use the new API, I realized that we introduced another breaking change. Imports like `import connectToStores from 'fluxible-addonts-react/connectToStores'` don't work anymore since we're transpiling the code to the `dist` folder. Users could import from `'fluxible-addonts-react/dist/connectToStores'` but I believe that it would be better to encourage only named imports from `'fluxible-addonts-react'` like:

```javascript
import { connectToStores } from 'fluxible-addons-react';
```

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
