### PR TITLE
fluxible-router: remove route from dehydrated state

### DIFF
--- a/packages/fluxible-router/lib/RouteStore.js
+++ b/packages/fluxible-router/lib/RouteStore.js
@@ -151,8 +151,9 @@ var RouteStore = createStore({
     dehydrate: function () {
         // no need to dehydrate this._prevNavigate, because it will always
         // be null on server request
+        var currentNavigate = Object.assign({}, this._currentNavigate, {route: null});
         return {
-            currentNavigate: this._currentNavigate,
+            currentNavigate: currentNavigate,
             routes: this._routes
         };
     },

--- a/packages/fluxible-router/tests/unit/lib/RouteStore-test.js
+++ b/packages/fluxible-router/tests/unit/lib/RouteStore-test.js
@@ -35,6 +35,7 @@ describe('RouteStore', function () {
                 expect(state.currentNavigate.transactionId).to.equal('first');
                 expect(state.currentNavigate.url).to.equal('/foo');
                 expect(state.currentNavigate.method).to.equal('get');
+                expect(state.currentNavigate.route).to.equal(null);
                 expect(state.routes).to.equal(null);
             });
         });


### PR DESCRIPTION
Closes #522 (and unsolved #439)

@redonkulus we're facing the issues mentioned in the links above in my company. The summary is:

Given that:
- RouteStore is dehydrating the route handler and action,
- handler and action are nodejs compatible code and
- [RouteStore doesn't need this data to re-hydrate](https://github.com/yahoo/fluxible/blob/fluxible-router-1.x/packages/fluxible-router/lib/RouteStore.js#L167).

The following problems occur:
- We are transferring way more data than we need for re-hydration (harming performance)
- The dehydrated state may even break the application (either by incompatible syntax or by a not found reference)

Previously we were doing some crazy workarounds on our application and I thought it was specific to us. But after checking #522, #439 and fluxible-router codebase, I realized that we could have this fixed in the package itself.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
