### PR TITLE
github is deprecating API auth through query params

### DIFF
--- a/site/services/docs.js
+++ b/site/services/docs.js
@@ -62,10 +62,14 @@ function fetchGitHubReposApi(params, cb) {
 
     // use access token if available, otherwise use client id and secret
     if (secrets.github.accessToken) {
-        githubUrl += qs.stringify({
-            access_token: secrets.github.accessToken
-        });
+        // using accessToken as query param is being deprecated
+        // https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/
+        // githubUrl += qs.stringify({
+        //     access_token: secrets.github.accessToken
+        // });
     } else {
+        // using clientId and clientSecret as query param is being deprecated as well.
+        // will remove this after switching fluxible.io to use accessToken.
         githubUrl += qs.stringify({
             client_id: secrets.github.clientId,
             client_secret: secrets.github.clientSecret
@@ -78,10 +82,19 @@ function fetchGitHubReposApi(params, cb) {
     }
     debug(githubUrl);
 
-    request
-        .get(githubUrl)
-        .set('User-Agent', 'superagent')
-        .end(cb);
+    if (secrets.github.accessToken) {
+        request
+            .get(githubUrl)
+            .set('User-Agent', 'superagent')
+            .set('Authorization', 'token ' + secrets.github.accessToken)
+            .end(cb);
+    } else {
+        // will remove this after switching fluxible.io to use accessToken.
+        request
+            .get(githubUrl)
+            .set('User-Agent', 'superagent')
+            .end(cb);
+    }
 }
 
 /**


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@redonkulus 

We need to switch to use access token for fluxible.io site, follow instructions in this deprecation notice: https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/

- switch to use access token in this PR
- will remove logic using client id and secret after fluxible.io is switched to access token. 