### PR TITLE
addons-react: add helpful error messages to improve debugging

### DIFF
--- a/packages/fluxible-addons-react/src/FluxibleContext.js
+++ b/packages/fluxible-addons-react/src/FluxibleContext.js
@@ -15,7 +15,7 @@ export class FluxibleProvider extends Component {
             getStore: this.props.context.getStore,
         };
 
-        this.props.plugins.forEach(plugin => {
+        this.props.plugins.forEach((plugin) => {
             state[plugin] = this.props.context[plugin];
         });
 
@@ -23,17 +23,21 @@ export class FluxibleProvider extends Component {
     }
 
     render() {
-        const props =  { value: this.state };
-        return createElement(FluxibleContext.Provider, props, this.props.children);
+        const props = { value: this.state };
+        return createElement(
+            FluxibleContext.Provider,
+            props,
+            this.props.children
+        );
     }
 }
 
 FluxibleProvider.propTypes = {
     children: node.isRequired,
     context: object.isRequired,
-    plugins: arrayOf(string)
+    plugins: arrayOf(string),
 };
 
 FluxibleProvider.defaultProps = {
-    plugins: []
+    plugins: [],
 };

--- a/packages/fluxible-addons-react/src/FluxibleContext.js
+++ b/packages/fluxible-addons-react/src/FluxibleContext.js
@@ -1,9 +1,15 @@
 import { Component, createContext, createElement } from 'react';
 import { arrayOf, node, object, string } from 'prop-types';
 
+const throwError = () => {
+    throw new Error(
+        'Fluxible context not found. Wrap your component with Fluxible component or provideContext.'
+    );
+};
+
 export const FluxibleContext = createContext({
-    executeAction: () => {},
-    getStore: () => {},
+    executeAction: throwError,
+    getStore: throwError,
 });
 
 export class FluxibleProvider extends Component {

--- a/packages/fluxible-addons-react/src/provideContext.js
+++ b/packages/fluxible-addons-react/src/provideContext.js
@@ -21,6 +21,12 @@ import { FluxibleProvider } from './FluxibleContext';
  * @returns {React.Component}
  */
 function provideContext(Component, plugins) {
+    if (plugins && !Array.isArray(plugins)) {
+        throw new TypeError(
+            'Invalid type for plugins. Starting from v1.0, plugins must be an array of plugin names.'
+        );
+    }
+
     class ContextProvider extends ReactComponent {
         constructor(props) {
             super(props);

--- a/packages/fluxible-addons-react/src/provideContext.js
+++ b/packages/fluxible-addons-react/src/provideContext.js
@@ -3,7 +3,7 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 import { Component as ReactComponent, createRef, createElement } from 'react';
-import { func, object } from 'prop-types';
+import { object } from 'prop-types';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import { FluxibleProvider } from './FluxibleContext';
 
@@ -28,21 +28,31 @@ function provideContext(Component, plugins) {
         }
 
         render() {
-            const props = (Component.prototype && Component.prototype.isReactComponent)
-                ? {ref: this.wrappedElementRef}
-                : null;
+            const props =
+                Component.prototype && Component.prototype.isReactComponent
+                    ? { ref: this.wrappedElementRef }
+                    : null;
 
             const { context } = this.props;
-            const children = createElement(Component, {...this.props, ...props});
-            return createElement(FluxibleProvider, { context, plugins }, children);
+            const children = createElement(Component, {
+                ...this.props,
+                ...props,
+            });
+            return createElement(
+                FluxibleProvider,
+                { context, plugins },
+                children
+            );
         }
     }
 
     ContextProvider.propTypes = {
-        context: object.isRequired
+        context: object.isRequired,
     };
 
-    ContextProvider.displayName = `contextProvider(${Component.displayName || Component.name || 'Component'})`;
+    ContextProvider.displayName = `contextProvider(${
+        Component.displayName || Component.name || 'Component'
+    })`;
 
     hoistNonReactStatics(ContextProvider, Component);
 

--- a/packages/fluxible-addons-react/tests/unit/lib/FluxibleContext.js
+++ b/packages/fluxible-addons-react/tests/unit/lib/FluxibleContext.js
@@ -1,0 +1,51 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import React, { useContext } from 'react';
+import { renderToString } from 'react-dom/server';
+
+import { FluxibleContext, FluxibleComponent } from '../../../';
+
+describe('FluxibleContext', () => {
+    it('provides access to getStore and executeAction', () => {
+        const context = {
+            getStore: sinon.stub(),
+            executeAction: sinon.stub(),
+        };
+
+        const Component = () => {
+            const { getStore, executeAction } = useContext(FluxibleContext);
+            getStore('SomeStore');
+            executeAction('SomeAction');
+            return null;
+        };
+
+        renderToString(
+            <FluxibleComponent context={context}>
+                <Component />
+            </FluxibleComponent>
+        );
+
+        sinon.assert.calledOnce(context.getStore);
+        sinon.assert.calledOnce(context.executeAction);
+    });
+
+    it('throws error if executeAction is called and no context is set', () => {
+        const Component = () => {
+            const { executeAction } = useContext(FluxibleContext);
+            executeAction('SomeAction');
+            return null;
+        };
+
+        expect(() => renderToString(<Component />)).to.throw(); // eslint-disable-line dot-notation
+    });
+
+    it('throws error if getStore is called and no context is set', () => {
+        const Component = () => {
+            const { getStore } = useContext(FluxibleContext);
+            getStore('SomeAction');
+            return null;
+        };
+
+        expect(() => renderToString(<Component />)).to.throw(); // eslint-disable-line dot-notation
+    });
+});

--- a/packages/fluxible-addons-react/tests/unit/lib/provideContext.js
+++ b/packages/fluxible-addons-react/tests/unit/lib/provideContext.js
@@ -39,7 +39,7 @@ describe('fluxible-addons-react', () => {
 
         it('should use the childs displayName', () => {
             class Component extends React.Component {
-                static displayName = 'TestComponent'
+                static displayName = 'TestComponent';
 
                 render() {
                     return null;
@@ -52,19 +52,21 @@ describe('fluxible-addons-react', () => {
             );
         });
 
-        it('should provide the context with custom types to children', () => {
+        it('should provide the context with plugins to children', () => {
             const plugins = ['foo'];
             const context = {
                 foo: 'bar',
-                executeAction: function() {},
-                getStore: function() {}
+                executeAction: function () {},
+                getStore: function () {},
             };
 
             class Component extends React.Component {
                 static contextType = FluxibleContext;
 
                 render() {
-                    expect(this.context.executeAction).to.equal(context.executeAction);
+                    expect(this.context.executeAction).to.equal(
+                        context.executeAction
+                    );
                     expect(this.context.getStore).to.equal(context.getStore);
                     expect(this.context.foo).to.equal(context.foo);
                     return null;
@@ -84,24 +86,28 @@ describe('fluxible-addons-react', () => {
             };
 
             class Component extends React.Component {
-                static displayName = 'Component'
+                static displayName = 'Component';
 
                 static initAction() {}
 
                 render() {
                     expect(this.context.foo).to.equal(context.foo);
-                    expect(this.context.executeAction).to.equal(context.executeAction);
+                    expect(this.context.executeAction).to.equal(
+                        context.executeAction
+                    );
                     expect(this.context.getStore).to.equal(context.getStore);
                     return null;
                 }
             }
 
             const WrappedComponent = provideContext(Component, {
-                foo: PropTypes.string
+                foo: PropTypes.string,
             });
 
             expect(WrappedComponent.initAction).to.be.a('function');
-            expect(WrappedComponent.displayName).to.not.equal(Component.displayName);
+            expect(WrappedComponent.displayName).to.not.equal(
+                Component.displayName
+            );
         });
 
         it('should add a ref to class components', () => {
@@ -119,7 +125,10 @@ describe('fluxible-addons-react', () => {
             const WrappedComponent = provideContext(Component, [], () => ({}));
 
             const container = document.createElement('div');
-            const component = ReactDOM.render(<WrappedComponent context={context} />, container);
+            const component = ReactDOM.render(
+                <WrappedComponent context={context} />,
+                container
+            );
             expect(component).to.include.keys('wrappedElementRef');
         });
 
@@ -129,10 +138,17 @@ describe('fluxible-addons-react', () => {
                 getStore: () => {},
             };
 
-            const WrappedComponent = provideContext(() => <noscript />, [], () => ({}));
+            const WrappedComponent = provideContext(
+                () => <noscript />,
+                [],
+                () => ({})
+            );
 
             const container = document.createElement('div');
-            const component = ReactDOM.render(<WrappedComponent context={context} />, container);
+            const component = ReactDOM.render(
+                <WrappedComponent context={context} />,
+                container
+            );
             expect(component.refs).to.not.include.keys('wrappedElement');
         });
     });

--- a/packages/fluxible-addons-react/tests/unit/lib/provideContext.js
+++ b/packages/fluxible-addons-react/tests/unit/lib/provideContext.js
@@ -78,31 +78,26 @@ describe('fluxible-addons-react', () => {
             renderToString(<WrappedComponent context={context} />);
         });
 
-        it('should hoist non-react statics to higher order component', () => {
-            const context = {
-                foo: 'bar',
-                executeAction: () => {},
-                getStore: () => {},
-            };
+        it('should throw error if plugins argument is not an array', () => {
+            const plugins = { foo: 'bar' };
+            const Component = () => null;
 
+            // eslint-disable-next-line dot-notation
+            expect(() => provideContext(Component, plugins)).to.throw();
+        });
+
+        it('should hoist non-react statics to higher order component', () => {
             class Component extends React.Component {
                 static displayName = 'Component';
 
                 static initAction() {}
 
                 render() {
-                    expect(this.context.foo).to.equal(context.foo);
-                    expect(this.context.executeAction).to.equal(
-                        context.executeAction
-                    );
-                    expect(this.context.getStore).to.equal(context.getStore);
                     return null;
                 }
             }
 
-            const WrappedComponent = provideContext(Component, {
-                foo: PropTypes.string,
-            });
+            const WrappedComponent = provideContext(Component);
 
             expect(WrappedComponent.initAction).to.be.a('function');
             expect(WrappedComponent.displayName).to.not.equal(


### PR DESCRIPTION
1. Since `provideContext` now accepts an array instead of an object, it would be better if we tell users that they forgot to update it. The previous behavior could lead to hard to find bugs due to missing plugin functionality.
2. Also, since connected components must have the fluxible context in its react context, it would also be better if we tell users that they forgot to wrap their components with `provideContext` or `FluxibleComponent`. The previous behavior would fail silently, making it hard to debug. 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
