### PR TITLE
fluxible-addons-react: add react 17 as peer dependency

### DIFF
--- a/packages/fluxible-addons-react/package.json
+++ b/packages/fluxible-addons-react/package.json
@@ -26,8 +26,8 @@
   },
   "peerDependencies": {
     "fluxible": ">=1.0.0",
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^16.3.0 || ^17.0.0",
+    "react-dom": "^16.3.0 || ^17.0.0"
   },
   "author": "Michael Ridgway <mridgway@yahoo-inc.com>",
   "license": "BSD-3-Clause"


### PR DESCRIPTION
The `examples/minimal`,  `examples/fluxible-router` and  `packages/generator` are already using react 17 and I haven't seen any issue so far.

@redonkulus after merging this one, it would be nice have another beta release. 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
