### PR TITLE
fluxible-router: add react 17 as peer dependency

### DIFF
--- a/packages/fluxible-router/package.json
+++ b/packages/fluxible-router/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "fluxible": "^1.0.0",
-    "react": "^16.3.0"
+    "react": "^16.3.0 || ^17.0.0"
   },
   "keywords": [
     "flux",


### PR DESCRIPTION
And also update `fluxible-addons-react` to the latest version (that was not release yet).

This PR will be red on travis until #691 is not published.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
