### PR TITLE
fluxible-addons-react: simplify provideContext and FluxibleComponent

### DIFF
--- a/packages/fluxible-addons-react/UPGRADE.md
+++ b/packages/fluxible-addons-react/UPGRADE.md
@@ -4,8 +4,9 @@
 
 ### imports
 
-Since the published version is a babel transpiled code that resides on a 
-dist folder, imports like `fluxible-addons-react/connectToStores` don't work anymore.
+Since the published version is a babel transpiled code that resides on
+a dist folder, imports like `fluxible-addons-react/connectToStores`
+don't work anymore.
 
 **Before**
 
@@ -23,11 +24,11 @@ import { connectToStores, provideContext } from 'fluxible-addonts-react';
 
 ### provideContext
 
-`provideContext(Component, customContextTypes)` -> `provideContext(Component, plugins)`
+`provideContext(Component, customContextTypes)` -> `provideContext(Component)`
 
-Since the new React API doesn't rely on PropTypes anymore, a list of
-plugins keys is enough to tell fluxible which custom data you would
-like to have available inside fluxible context.
+Since the new React API doesn't rely on PropTypes anymore, there is no
+need to pass an object with context types in order to forward plugins
+context to the components.
 
 **Before:**
 
@@ -43,9 +44,7 @@ provideContext(Component, customContextTypes)
 **After:**
 
 ```javascript
-const plugins = ['pluginBar', 'pluginFoo'];
-
-provideContext(Component, plugins)
+provideContext(Component)
 ```
 
 If you were using `provideContext` to provide other context data not
@@ -57,9 +56,8 @@ solution to achieve the same result as before.
 `connectToStores(Component, stores, getStateFromStores, customContextTypes)` -> `connectToStores(Component, stores, getStateFromStores)`
 
 Since the new React API doesn't rely on PropTypes anymore, there is no
-need to specify customContextTypes to extract from the fluxible
-context. The context available to your `getStateFromStores` will
-contain all the custom data specified in `provideContext`.
+need to specify customContextTypes to extract plugins context from the
+fluxible context since all plugins will be available.
 
 **Before:**
 
@@ -81,7 +79,7 @@ connectToStores(Component)
 If you were relying in other contextTypes that were not included in
 `provideContext` (non fluxible plugins), you will need to find another
 way to have it available in `getStateFromStores`. Since the second
-argument of `getStateFromStores` is props passed to the wrapped
+argument of `getStateFromStores` is the props passed to the wrapped
 component, you can create your own high order component that passes
 the required context as props to your connected component:
 

--- a/packages/fluxible-addons-react/src/FluxibleContext.js
+++ b/packages/fluxible-addons-react/src/FluxibleContext.js
@@ -1,5 +1,5 @@
-import { Component, createContext, createElement } from 'react';
-import { arrayOf, node, object, string } from 'prop-types';
+import { createContext, createElement } from 'react';
+import { node, object } from 'prop-types';
 
 const throwError = () => {
     throw new Error(
@@ -12,38 +12,12 @@ export const FluxibleContext = createContext({
     getStore: throwError,
 });
 
-export class FluxibleProvider extends Component {
-    constructor(props) {
-        super(props);
+FluxibleContext.displayName = 'FluxibleContext';
 
-        const state = {
-            executeAction: this.props.context.executeAction,
-            getStore: this.props.context.getStore,
-        };
-
-        this.props.plugins.forEach((plugin) => {
-            state[plugin] = this.props.context[plugin];
-        });
-
-        this.state = state;
-    }
-
-    render() {
-        const props = { value: this.state };
-        return createElement(
-            FluxibleContext.Provider,
-            props,
-            this.props.children
-        );
-    }
-}
+export const FluxibleProvider = ({ children, context }) =>
+    createElement(FluxibleContext.Provider, { value: context }, children);
 
 FluxibleProvider.propTypes = {
     children: node.isRequired,
     context: object.isRequired,
-    plugins: arrayOf(string),
-};
-
-FluxibleProvider.defaultProps = {
-    plugins: [],
 };

--- a/packages/fluxible-addons-react/src/provideContext.js
+++ b/packages/fluxible-addons-react/src/provideContext.js
@@ -17,16 +17,9 @@ import { FluxibleProvider } from './FluxibleContext';
  *
  * @method provideContext
  * @param {React.Component} [Component] component to wrap
- * @param {array} [plugins] list of plugins names to inject into the context
  * @returns {React.Component}
  */
-function provideContext(Component, plugins) {
-    if (plugins && !Array.isArray(plugins)) {
-        throw new TypeError(
-            'Invalid type for plugins. Starting from v1.0, plugins must be an array of plugin names.'
-        );
-    }
-
+function provideContext(Component) {
     class ContextProvider extends ReactComponent {
         constructor(props) {
             super(props);
@@ -44,11 +37,7 @@ function provideContext(Component, plugins) {
                 ...this.props,
                 ...props,
             });
-            return createElement(
-                FluxibleProvider,
-                { context, plugins },
-                children
-            );
+            return createElement(FluxibleProvider, { context }, children);
         }
     }
 

--- a/packages/fluxible-addons-react/tests/unit/lib/FluxibleComponent.js
+++ b/packages/fluxible-addons-react/tests/unit/lib/FluxibleComponent.js
@@ -2,11 +2,9 @@
 /* eslint react/prop-types:0, react/no-render-return-value:0, react/no-find-dom-node:0 */
 import { expect } from 'chai';
 import React from 'react';
-import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
 import { JSDOM } from 'jsdom';
 import createMockComponentContext from 'fluxible/utils/createMockComponentContext';
-import createReactClass from 'create-react-class';
 import sinon from 'sinon';
 
 import { FluxibleComponent } from '../../../';
@@ -24,7 +22,7 @@ describe('fluxible-addons-react', () => {
             global.navigator = jsdom.window.navigator;
 
             context = createMockComponentContext({
-                stores: [FooStore, BarStore]
+                stores: [FooStore, BarStore],
             });
         });
 
@@ -35,10 +33,10 @@ describe('fluxible-addons-react', () => {
         });
 
         it('will not double render', () => {
-            const spy = sinon.spy()
+            const spy = sinon.spy();
             class Component extends React.Component {
                 render() {
-                    spy()
+                    spy();
                     return (
                         <div className="Component">{this.props.children}</div>
                     );

--- a/packages/fluxible-addons-react/tests/unit/lib/provideContext.js
+++ b/packages/fluxible-addons-react/tests/unit/lib/provideContext.js
@@ -4,7 +4,6 @@ import { expect } from 'chai';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { renderToString } from 'react-dom/server';
-import PropTypes from 'prop-types';
 import { JSDOM } from 'jsdom';
 
 import { provideContext, FluxibleContext } from '../../../';
@@ -52,7 +51,6 @@ describe('fluxible-addons-react', () => {
         });
 
         it('should provide the context with plugins to children', () => {
-            const plugins = ['foo'];
             const context = {
                 foo: 'bar',
                 executeAction: function () {},
@@ -61,27 +59,15 @@ describe('fluxible-addons-react', () => {
 
             class Component extends React.Component {
                 render() {
-                    expect(this.context.executeAction).to.equal(
-                        context.executeAction
-                    );
-                    expect(this.context.getStore).to.equal(context.getStore);
-                    expect(this.context.foo).to.equal(context.foo);
+                    expect(this.context).to.deep.equal(context);
                     return null;
                 }
             }
             Component.contextType = FluxibleContext;
 
-            const WrappedComponent = provideContext(Component, plugins);
+            const WrappedComponent = provideContext(Component);
 
             renderToString(<WrappedComponent context={context} />);
-        });
-
-        it('should throw error if plugins argument is not an array', () => {
-            const plugins = { foo: 'bar' };
-            const Component = () => null;
-
-            // eslint-disable-next-line dot-notation
-            expect(() => provideContext(Component, plugins)).to.throw();
         });
 
         it('should hoist non-react statics to higher order component', () => {
@@ -114,7 +100,7 @@ describe('fluxible-addons-react', () => {
                 }
             }
 
-            const WrappedComponent = provideContext(Component, [], () => ({}));
+            const WrappedComponent = provideContext(Component);
 
             const container = document.createElement('div');
             const component = ReactDOM.render(
@@ -130,11 +116,7 @@ describe('fluxible-addons-react', () => {
                 getStore: () => {},
             };
 
-            const WrappedComponent = provideContext(
-                () => <noscript />,
-                [],
-                () => ({})
-            );
+            const WrappedComponent = provideContext(() => <noscript />);
 
             const container = document.createElement('div');
             const component = ReactDOM.render(


### PR DESCRIPTION
- Forward the whole component context to the components
- Remove plugins from provideContext signature and from FluxibleComponent props

Reasoning: with the new React Context API, we don't need to specify contextTypes in order to retrieve fluxible plugins context.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
