### PR TITLE
Improve ref support on connectToStores (and remove refs from other components)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "lint": "eslint .",
     "test": "lerna run lint --since --stream && lerna run test --since --stream"
   },
-  "dependencies": {},
   "devDependencies": {
     "@babel/cli": "^7.11.6",
     "@babel/core": "^7.11.6",
@@ -43,6 +42,7 @@
     "pre-commit": "^1.0.7",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
+    "react-test-renderer": "^16.0.0",
     "shelljs": "^0.8.0",
     "sinon": "^9.0.1",
     "yargs": "^16.0.0"

--- a/packages/fluxible-addons-react/src/connectToStores.js
+++ b/packages/fluxible-addons-react/src/connectToStores.js
@@ -2,7 +2,7 @@
  * Copyright 2015, Yahoo Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
-import { Component as ReactComponent, createRef, createElement } from 'react';
+import { Component as ReactComponent, createElement } from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import { FluxibleContext } from './FluxibleContext';
 
@@ -35,7 +35,6 @@ function connectToStores(Component, stores, getStateFromStores) {
             this._onStoreChange = this._onStoreChange.bind(this);
             this.getStateFromStores = this.getStateFromStores.bind(this);
             this.state = this.getStateFromStores();
-            this.wrappedElementRef = createRef();
         }
 
         getStateFromStores(props) {
@@ -64,10 +63,7 @@ function connectToStores(Component, stores, getStateFromStores) {
         }
 
         render() {
-            const props = (Component.prototype && Component.prototype.isReactComponent)
-                ? {ref: this.wrappedElementRef}
-                : null;
-            return createElement(Component, {...this.props, ...this.state, ...props});
+            return createElement(Component, {...this.props, ...this.state });
         }
     }
 

--- a/packages/fluxible-addons-react/src/connectToStores.js
+++ b/packages/fluxible-addons-react/src/connectToStores.js
@@ -7,25 +7,29 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 import { FluxibleContext } from './FluxibleContext';
 
 /**
- * Registers change listeners and retrieves state from stores using the `getStateFromStores`
- * method. Concept provided by Dan Abramov via
- * https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750
+ * @callback getStateFromStores
+ * @param {FluxibleContext} context - Fluxible component context.
+ * @param {Object} ownProps - The props that the component received.
+ * @returns {Object} props - The props that should be passed to the component.
+ */
+
+/**
+ * HOC that registers change listeners and retrieves state from stores
+ * using the `getStateFromStores` method.
  *
  * Example:
- *   connectToStores(Component, [FooStore], {
- *       FooStore: function (store, props) {
- *           return {
- *               foo: store.getFoo()
- *           }
- *       }
+ *   connectToStores(Component, [FooStore], (context, props) => ({
+ *       foo: context.getStore(FooStore).getFoo(),
+ *       onClick: () => context.executeAction(fooAction, props)
  *   })
  *
- * @method connectToStores
- * @param {React.Component} [Component] component to pass state as props to.
- * @param {array} stores List of stores to listen for changes
- * @param {function} getStateFromStores function that receives all stores and should return
- *      the full state object. Receives `stores` hash and component `props` as arguments
- * @returns {React.Component} or {Function} if using decorator pattern
+ * @function connectToStores
+ * @param {React.Component} Component - The component to pass state as props to.
+ * @param {array} stores - List of stores to listen for changes.
+ * @param {getStateFromStores} getStateFromStores - The main function that must map the context into props.
+ * @param {Object} [options] - options to tweak the HOC.
+ * @param {boolean} options.forwardRef - If true, forwards a ref to the wrapped component.
+ * @returns {React.Component} ConnectedComponent - A component connected to the stores.
  */
 function connectToStores(Component, stores, getStateFromStores, options) {
     class StoreConnector extends ReactComponent {

--- a/packages/fluxible-addons-react/src/provideContext.js
+++ b/packages/fluxible-addons-react/src/provideContext.js
@@ -2,7 +2,7 @@
  * Copyright 2015, Yahoo Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
-import { Component as ReactComponent, createRef, createElement } from 'react';
+import { Component as ReactComponent, createElement } from 'react';
 import { object } from 'prop-types';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import { FluxibleProvider } from './FluxibleContext';
@@ -23,20 +23,11 @@ function provideContext(Component) {
     class ContextProvider extends ReactComponent {
         constructor(props) {
             super(props);
-            this.wrappedElementRef = createRef();
         }
 
         render() {
-            const props =
-                Component.prototype && Component.prototype.isReactComponent
-                    ? { ref: this.wrappedElementRef }
-                    : null;
-
             const { context } = this.props;
-            const children = createElement(Component, {
-                ...this.props,
-                ...props,
-            });
+            const children = createElement(Component, this.props);
             return createElement(FluxibleProvider, { context }, children);
         }
     }

--- a/packages/fluxible-addons-react/tests/unit/lib/connectToStores.js
+++ b/packages/fluxible-addons-react/tests/unit/lib/connectToStores.js
@@ -4,7 +4,6 @@ import { expect } from 'chai';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
-import PropTypes from 'prop-types';
 import { JSDOM } from 'jsdom';
 import createMockComponentContext from 'fluxible/utils/createMockComponentContext';
 
@@ -35,8 +34,6 @@ describe('fluxible-addons-react', () => {
 
         it('should get the state from the stores', (done) => {
             class Component extends React.Component {
-
-
                 constructor() {
                     super();
                     this.onClick = this.onClick.bind(this);
@@ -82,36 +79,6 @@ describe('fluxible-addons-react', () => {
             expect(appContext.getStore(BarStore).listeners('change').length).to.equal(0);
             expect(appContext.getStore(FooStore).listeners('change').length).to.equal(0);
             done();
-        });
-
-        describe('refs', () => {
-            const hasWrappedComponentRef = component => {
-                const contextProvider = component;
-                const storeConnector = contextProvider.wrappedElementRef.current;
-                const wrappedElement = storeConnector.wrappedElementRef.current;
-                return Boolean(wrappedElement);
-            };
-
-            it('should add a ref to class components', () => {
-                class Component extends React.Component {
-                    render() {
-                        return <noscript />;
-                    }
-                }
-                const WrappedComponent = provideContext(connectToStores(Component, [], () => ({})));
-
-                const container = document.createElement('div');
-                const component = ReactDOM.render(<WrappedComponent context={appContext}/>, container);
-                expect(hasWrappedComponentRef(component)).to.equal(true);
-            });
-
-            it('should not add a ref to pure function components', () => {
-                const WrappedComponent = provideContext(connectToStores(() => <noscript />, [], () => ({})));
-
-                const container = document.createElement('div');
-                const component = ReactDOM.render(<WrappedComponent context={appContext} />, container);
-                expect(hasWrappedComponentRef(component)).to.equal(false);
-            });
         });
 
         it('should hoist non-react statics to higher order component', () => {

--- a/packages/fluxible-addons-react/tests/unit/lib/connectToStores.js
+++ b/packages/fluxible-addons-react/tests/unit/lib/connectToStores.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import { expect } from 'chai';
-import React from 'react';
+import React, { forwardRef, useImperativeHandle } from 'react';
 import TestRenderer from 'react-test-renderer';
 import createMockComponentContext from 'fluxible/utils/createMockComponentContext';
 
@@ -91,6 +91,67 @@ describe('fluxible-addons-react', () => {
 
             expect(component.props.foo).to.equal('barbar');
             expect(component.props.bar).to.equal('bazbaz');
+        });
+
+        describe('ref support', () => {
+            class ClassComponent extends React.Component {
+                constructor() {
+                    super();
+                    this.number = 42;
+                }
+                render() {
+                    return null;
+                }
+            }
+
+            const ConnectedClassComponent = connectToStores(
+                ClassComponent,
+                stores,
+                getStateFromStores,
+                { forwardRef: true }
+            );
+
+            const ForwardComponent = forwardRef((props, ref) => {
+                useImperativeHandle(ref, () => ({ number: 24 }));
+                return <div {...props} />;
+            });
+            ForwardComponent.displayName = 'ForwardComponent';
+
+            const ConnectedForwardComponent = connectToStores(
+                ForwardComponent,
+                stores,
+                getStateFromStores,
+                { forwardRef: true }
+            );
+
+            const WithoutRefComponent = connectToStores(
+                DumbComponent,
+                stores,
+                getStateFromStores,
+                { forwardRef: false }
+            );
+
+            it('should not forward ref by default', () => {
+                const ref = React.createRef(null);
+                renderComponent(ConnectedComponent, ref);
+                expect(ref.current).to.equal(null);
+            });
+
+            it('should not forward ref if options.forwardRef is false', () => {
+                const ref = React.createRef(null);
+                renderComponent(WithoutRefComponent, ref);
+                expect(ref.current).to.equal(null);
+            });
+
+            it('should forward ref if options.forwardRef is true', () => {
+                const ref1 = React.createRef(null);
+                renderComponent(ConnectedClassComponent, ref1);
+                expect(ref1.current.number).to.equal(42);
+
+                const ref2 = React.createRef(null);
+                renderComponent(ConnectedForwardComponent, ref2);
+                expect(ref2.current.number).to.equal(24);
+            });
         });
     });
 });

--- a/packages/fluxible-addons-react/tests/unit/lib/provideContext.js
+++ b/packages/fluxible-addons-react/tests/unit/lib/provideContext.js
@@ -2,7 +2,6 @@
 /* eslint react/no-render-return-value:0 */
 import { expect } from 'chai';
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { renderToString } from 'react-dom/server';
 import { JSDOM } from 'jsdom';
 
@@ -86,44 +85,6 @@ describe('fluxible-addons-react', () => {
             expect(WrappedComponent.displayName).to.not.equal(
                 Component.displayName
             );
-        });
-
-        it('should add a ref to class components', () => {
-            const context = {
-                executeAction: () => {},
-                getStore: () => {},
-            };
-
-            class Component extends React.Component {
-                render() {
-                    return <noscript />;
-                }
-            }
-
-            const WrappedComponent = provideContext(Component);
-
-            const container = document.createElement('div');
-            const component = ReactDOM.render(
-                <WrappedComponent context={context} />,
-                container
-            );
-            expect(component).to.include.keys('wrappedElementRef');
-        });
-
-        it('should not add a ref to pure function components', () => {
-            const context = {
-                executeAction: () => {},
-                getStore: () => {},
-            };
-
-            const WrappedComponent = provideContext(() => <noscript />);
-
-            const container = document.createElement('div');
-            const component = ReactDOM.render(
-                <WrappedComponent context={context} />,
-                container
-            );
-            expect(component.refs).to.not.include.keys('wrappedElement');
         });
     });
 });

--- a/packages/fluxible-router/src/lib/handleHistory.js
+++ b/packages/fluxible-router/src/lib/handleHistory.js
@@ -2,7 +2,8 @@
  * Copyright 2015, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
-/*global window */
+/* global window */
+/* eslint-disable react/display-name */
 'use strict';
 var React = require('react');
 var PropTypes = require('prop-types');
@@ -283,8 +284,7 @@ function createComponent(Component, opts) {
         },
 
         render: function () {
-            var props = Component.prototype && Component.prototype.isReactComponent ? {ref: 'wrappedElement'} : null;
-            return React.createElement(Component, Object.assign({}, this.props, props));
+            return React.createElement(Component, this.props);
         }
     });
 

--- a/packages/fluxible-router/src/lib/handleRoute.js
+++ b/packages/fluxible-router/src/lib/handleRoute.js
@@ -2,8 +2,9 @@
  * Copyright 2015, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
-/*global window */
-/*eslint no-func-assign:0 */
+/* global window */
+/* eslint no-func-assign:0 */
+/* eslint-disable react/display-name */
 'use strict';
 var React = require('react');
 var PropTypes = require('prop-types');
@@ -30,12 +31,11 @@ function createComponent(Component) {
     Object.assign(RouteHandler.prototype, {
         render: function () {
             var routeStore = this.context.getStore('RouteStore');
-            var props = Component.prototype && Component.prototype.isReactComponent ? {ref: 'wrappedElement'} : null;
 
             return React.createElement(Component, Object.assign({
                 isActive: routeStore.isActive.bind(routeStore),
                 makePath: routeStore.makePath.bind(routeStore)
-            }, this.props, props));
+            }, this.props));
         }
     });
 

--- a/packages/fluxible-router/tests/unit/lib/handleHistory-test.js
+++ b/packages/fluxible-router/tests/unit/lib/handleHistory-test.js
@@ -116,37 +116,6 @@ describe('handleHistory', function () {
         });
     });
 
-    describe('refs', function () {
-        const hasWrappedElementRef = component => {
-            const contextProvider = component;
-            const storeConnector = contextProvider.wrappedElementRef.current;
-            const routeHandler = storeConnector.wrappedElementRef.current;
-            const historyHandler = routeHandler.refs.wrappedElement;
-            const wrappedElement = historyHandler.refs.wrappedElement;
-            return Boolean(wrappedElement);
-        };
-
-        it('should add a ref to class components', function () {
-            class Component extends React.Component {
-                render() {
-                    return <noscript/>;
-                }
-            }
-
-            const WrappedComponent = provideContext(handleHistory(Component));
-            const component = ReactTestUtils.renderIntoDocument(<WrappedComponent context={mockContext}/>);
-
-            expect(hasWrappedElementRef(component)).to.equal(true);
-        });
-
-        it('should not add a ref to pure function components', function () {
-            var WrappedComponent = provideContext(handleHistory(() => <noscript/>));
-            var component = ReactTestUtils.renderIntoDocument(<WrappedComponent context={mockContext}/>);
-
-            expect(hasWrappedElementRef(component)).to.equal(false);
-        });
-    });
-
     describe('wrappedCreator', function () {
         var mockCreator;
 

--- a/packages/fluxible-router/tests/unit/lib/handleRoute-test.js
+++ b/packages/fluxible-router/tests/unit/lib/handleRoute-test.js
@@ -2,75 +2,36 @@
  * Copyright 2015, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
+import React from 'react';
+import { expect } from 'chai';
+import TestRenderer from 'react-test-renderer';
+import createMockComponentContext from 'fluxible/utils/createMockComponentContext';
+import { provideContext } from 'fluxible-addons-react';
+import { handleRoute, RouteStore } from '../../../';
 
-var expect = require('chai').expect;
-var JSDOM = require('jsdom').JSDOM;
-var React;
-var ReactDOM;
-var RouteStore = require('../../../dist/lib/RouteStore');
-var createMockComponentContext = require('fluxible/utils/createMockComponentContext');
-var ReactTestUtils;
-var TestRouteStore = RouteStore.withStaticRoutes({
-    foo: { path: '/foo', method: 'get' },
-    fooA: { path: '/foo/:a', method: 'get' },
-    fooAB: { path: '/foo/:a/:b', method: 'get' },
-    pathFromHistory: { path: '/the_path_from_history', method: 'get' },
-    unicode: { path: 'föö', method: 'get' }
-});
+const DumbComponent = () => null;
 
-describe('handleRoute', function () {
-    var provideContext;
-    var handleRoute;
-    var mockContext;
+const TestRouteStore = RouteStore.withStaticRoutes({});
 
-    beforeEach(function () {
-        var jsdom = new JSDOM('<html><body></body></html>');
-        global.window = jsdom.window;
-        global.document = jsdom.window.document;
-        global.navigator = jsdom.window.navigator;
-
-        React = require('react');
-        ReactDOM = require('react-dom');
-        ReactTestUtils = require('react-dom/test-utils');
-        provideContext = require('fluxible-addons-react').provideContext;
-        handleRoute = require('../../../').handleRoute;
-        mockContext = createMockComponentContext({
-            stores: [TestRouteStore]
-        });
-    });
-
-    afterEach(function () {
-        delete global.window;
-        delete global.document;
-        delete global.navigator;
-    });
-
-    describe('refs', function () {
-        const hasWrappedElementRef = component => {
-            const contextProvider = component;
-            const storeConnector = contextProvider.wrappedElementRef.current;
-            const routeHandler = storeConnector.wrappedElementRef.current;
-            const wrappedElement = routeHandler.refs.wrappedElement;
-            return Boolean(wrappedElement);
-        };
-
-        it('should add a ref to class components', function () {
-            class Component extends React.Component {
-                render() {
-                    return <noscript/>;
-                }
-            }
-            var WrappedComponent = provideContext(handleRoute(Component));
-
-            var component = ReactTestUtils.renderIntoDocument(<WrappedComponent context={mockContext}/>);
-            expect(hasWrappedElementRef(component)).to.equal(true);
+describe('handleRoute', () => {
+    it('pass correct props to children', () => {
+        const context = createMockComponentContext({
+            stores: [TestRouteStore],
         });
 
-        it('should not add a ref to pure function components', function () {
-            var WrappedComponent = provideContext(handleRoute(() => <noscript/>));
+        const props = { foo: 42, context };
+        const WrappedComponent = provideContext(handleRoute(DumbComponent));
+        const renderer = TestRenderer.create(<WrappedComponent {...props} />);
+        const component = renderer.root.findByType(DumbComponent);
 
-            var component = ReactTestUtils.renderIntoDocument(<WrappedComponent context={mockContext}/>);
-            expect(hasWrappedElementRef(component)).to.equal(false);
-        });
+        expect(component.props.foo).to.equal(42);
+        expect(component.props.context).to.deep.equal(context);
+        expect(component.props.currentNavigate).to.equal(null);
+        expect(component.props.currentNavigateError).to.equal(null);
+        expect(component.props.currentRoute).to.equal(null);
+        expect(component.props.isNavigateComplete).to.equal(null);
+
+        expect(component.props.isActive).to.be.a('function');
+        expect(component.props.makePath).to.be.a('function');
     });
 });


### PR DESCRIPTION
*addons-react/connectToStores*
- refactored tests
- removed `wrappedElementRef` ref
- add support for `React.forwardRef` with `{ forwardRef: true }`

*router/handleHistory*
- removed `wrappedElement` ref

*router/handleRoute*
- replaced refs test with a test that checks if props are passed correctly
- removed `wrappedElement` ref

*addons-react/batchedUpdatePlugin*
- refactored tests to not rely on refs

*addons-react/provideContext*
- removed `wrappedElementRef` ref

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
