### PR TITLE
Remove warnings on fluxible-router tests 

### DIFF
--- a/packages/fluxible-router/tests/unit/lib/NavLink-test.js
+++ b/packages/fluxible-router/tests/unit/lib/NavLink-test.js
@@ -45,6 +45,7 @@ function setup(options, done) {
     var jsdom = new JSDOM('<html><body></body></html>', { url: 'http://yahoo.com' });
     global.document = jsdom.window.document;
     global.window = jsdom.window;
+    global.window.scrollTo = (x, y) => ({ x, y });
     global.navigator = jsdom.window.navigator;
 
     React = require('react');


### PR DESCRIPTION
fluxible-router tests were being flooded by JSDOM warnings like:

```bash
fluxible-router: Error: Not implemented: window.scrollTo
fluxible-router:     at module.exports (/home/ppalacios/projects/fluxible/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
fluxible-router:     at Window.scrollTo (/home/ppalacios/projects/fluxible/node_modules/jsdom/lib/jsdom/browser/Window.js:866:7)
......
```

Mocking scrollTo solves the problem.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
