### PR TITLE
site: disable server page caching

### DIFF
--- a/site/server.js
+++ b/site/server.js
@@ -45,7 +45,9 @@ server.use(
 
 server.set('state namespace', 'App');
 server.use(favicon(path.join(__dirname, '/assets/images/favicon.ico')));
-server.use('/public', express['static'](path.join(__dirname, '/build')));
+server.use('/public', express['static'](path.join(__dirname, '/build'), {
+    maxAge: '1y'
+}));
 server.use(cookieParser());
 server.use(bodyParser.json());
 server.use(csrf({ cookie: true }));

--- a/site/server.js
+++ b/site/server.js
@@ -55,7 +55,7 @@ server.use(csrf({ cookie: true }));
 // Disable proxies from caching the page (static css/js assets are still cached)
 server.set('etag', false);
 server.use((req, res, next) => {
-    res.set('Cache-Control', 'no-store, max-age=0');
+    res.set('Cache-Control', 'private, no-store, max-age=0');
     next();
 });
 

--- a/site/server.js
+++ b/site/server.js
@@ -55,8 +55,7 @@ server.use(csrf({ cookie: true }));
 // Disable proxies from caching the page (static css/js assets are still cached)
 server.set('etag', false);
 server.use((req, res, next) => {
-    res.set('Cache-Control', 'no-store');
-    res.set('Max-Age', '0');
+    res.set('Cache-Control', 'no-store, max-age=0');
     next();
 });
 

--- a/site/server.js
+++ b/site/server.js
@@ -50,6 +50,14 @@ server.use(cookieParser());
 server.use(bodyParser.json());
 server.use(csrf({ cookie: true }));
 
+// Disable proxies from caching the page (static css/js assets are still cached)
+server.set('etag', false);
+server.use((req, res, next) => {
+    res.set('Cache-Control', 'no-store');
+    res.set('Max-Age', '0');
+    next();
+});
+
 // Get access to the fetchr plugin instance
 const fetchrPlugin = app.getPlugin('FetchrPlugin');
 


### PR DESCRIPTION
We discovered server proxies are caching the page and preventing server updates from being displayed. Disabling cache for server page responses to avoid this. CSS/JS assets are still cached but with a longer cache expiration now.

Page server:
<img width="594" alt="Screen Shot 2021-07-28 at 10 00 03 AM" src="https://user-images.githubusercontent.com/193272/127365019-220ded7c-570d-44e9-8a06-4e47aa8ea16f.png">

Assets:
<img width="627" alt="Screen Shot 2021-07-28 at 10 00 47 AM" src="https://user-images.githubusercontent.com/193272/127365138-d332ddc2-0eb5-4934-90eb-b18afa42f195.png">


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

