### PR TITLE
chore(deps): use routr@3

### DIFF
--- a/packages/fluxible-router/package.json
+++ b/packages/fluxible-router/package.json
@@ -32,7 +32,7 @@
     "fluxible-addons-react": "^1.0.0",
     "hoist-non-react-statics": "^3.3.2",
     "prop-types": "^15.7.2",
-    "routr": "^3.0.0"
+    "routr": "^3.0.1"
   },
   "peerDependencies": {
     "fluxible": "^1.0.0",

--- a/packages/fluxible-router/package.json
+++ b/packages/fluxible-router/package.json
@@ -32,7 +32,7 @@
     "fluxible-addons-react": "^1.0.0",
     "hoist-non-react-statics": "^3.3.2",
     "prop-types": "^15.7.2",
-    "routr": "^2.0.0"
+    "routr": "^3.0.0"
   },
   "peerDependencies": {
     "fluxible": "^1.0.0",

--- a/packages/fluxible-router/tests/unit/navigateAction-test.js
+++ b/packages/fluxible-router/tests/unit/navigateAction-test.js
@@ -89,7 +89,7 @@ describe('navigateAction', function () {
             expect(mockContext.dispatchCalls.length).to.equal(2);
             expect(mockContext.dispatchCalls[0].name).to.equal('NAVIGATE_START');
             var route = mockContext.getStore('RouteStore').getCurrentRoute();
-            expect(route.query).to.eql({foo: 'bar', a: ['b', 'c'], bool: null}, 'query added to route payload for NAVIGATE_START' + JSON.stringify(route));
+            expect(route.query).to.eql({foo: 'bar', a: ['b', 'c'], bool: ''}, 'query added to route payload for NAVIGATE_START' + JSON.stringify(route));
             expect(mockContext.dispatchCalls[1].name).to.equal('NAVIGATE_SUCCESS');
             var navigateSuccessPayload = mockContext.dispatchCalls[1].payload;
             expect(navigateSuccessPayload.route.url).to.equal(url.split('#')[0]);


### PR DESCRIPTION
@pablopalacios Pushing this up so you can see the failed unit test, looks like the changes in path-to-regexp could lead to issues for apps:

```
  1) navigateAction
       should include query param on route match:

      AssertionError: query added to route payload for NAVIGATE_START{"method":"get","path":"/","name":"home","url":"/?foo=bar&a=b&a=c&bool","params":{},"query":{"foo":"bar","a":"c","bool":""}}: expected { foo: 'bar', a: 'c', bool: '' } to deeply equal { Object (foo, a, ...) }
      + expected - actual

       {
      -  "a": "c"
      -  "bool": ""
      +  "a": [
      +    "b"
      +    "c"
      +  ]
      +  "bool": [null]
         "foo": "bar"
       }
```

You can see the error here https://github.com/yahoo/fluxible/pull/730/checks?check_run_id=3437749374


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
