### PR TITLE
docs(examples): add a stales props example

### DIFF
--- a/examples/stale-props/README.md
+++ b/examples/stale-props/README.md
@@ -1,0 +1,32 @@
+# Stale props example
+
+This example shows how to handle the stale props issue. The stale
+props issue happens when the following conditions are met:
+
+1. A child component relies on its props to retrieve data from the store
+2. The child component subscribes to the store before its parent.
+
+A concrete example would be a TODO app with the follow features:
+
+1. It populates the store in the client with data from the server
+   through the rehydration (SSR).
+2. The parent component would be a list that retrieves only the items
+   ids from the store and renders each item by passing only their ids
+   as props.
+3. The child component would be each item that takes the id from the
+   props and retrieves the remaining data from the store by
+   subscribing to it.
+
+In the above scenario, after deleting one item that came from the
+rehydration process, the app could crash if the item component is not
+handling the case where the item content doesn't exist anymore in the
+store.
+
+This examples shows a possibility on how to handle the above case.
+
+## How to run it
+
+```bash
+npm install
+npm start
+```

--- a/examples/stale-props/package.json
+++ b/examples/stale-props/package.json
@@ -1,0 +1,28 @@
+{
+    "name": "stale-props",
+    "version": "0.1.0",
+    "private": true,
+    "dependencies": {
+        "@testing-library/jest-dom": "^5.11.4",
+        "@testing-library/react": "^11.1.0",
+        "@testing-library/user-event": "^12.1.10",
+        "fluxible": "^1.4.2",
+        "fluxible-addons-react": "^1.0.0",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
+        "react-scripts": "4.0.3",
+        "web-vitals": "^1.0.1"
+    },
+    "scripts": {
+        "start": "react-scripts start",
+        "build": "react-scripts build",
+        "test": "react-scripts test",
+        "eject": "react-scripts eject"
+    },
+    "eslintConfig": {
+        "extends": [
+            "react-app",
+            "react-app/jest"
+        ]
+    }
+}

--- a/examples/stale-props/public/index.html
+++ b/examples/stale-props/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Stale props example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/examples/stale-props/src/App.js
+++ b/examples/stale-props/src/App.js
@@ -1,0 +1,13 @@
+import List from './List';
+import Input from './Input';
+
+function App() {
+    return (
+        <div>
+            <Input />
+            <List />
+        </div>
+    );
+}
+
+export default App;

--- a/examples/stale-props/src/Input.js
+++ b/examples/stale-props/src/Input.js
@@ -1,0 +1,24 @@
+import { useRef } from 'react';
+import { useFluxible } from 'fluxible-addons-react';
+import { addItem } from './actions';
+
+const Input = () => {
+    const ref = useRef();
+    const { executeAction } = useFluxible();
+
+    return (
+        <div>
+            <input ref={ref} />
+            <button
+                onClick={() => {
+                    executeAction(addItem, { label: ref.current.value });
+                    ref.current.value = '';
+                }}
+            >
+                Add item
+            </button>
+        </div>
+    );
+};
+
+export default Input;

--- a/examples/stale-props/src/Item.js
+++ b/examples/stale-props/src/Item.js
@@ -1,0 +1,33 @@
+import { connectToStores } from 'fluxible-addons-react';
+import { removeItem } from './actions';
+import ListStore from './ListStore';
+
+const Item = ({ item, remove }) => {
+    // To avoid the stale props issue, you must always check if the
+    // item retrived from the store exists or not.
+
+    // If you remove the following check, as soon as you delete an
+    // item from the initial state, this component will throw an
+    // exception since item will be undefined. This happens because
+    // the initial items subscribe to the store before the List
+    // component since React runs the lifecycle methods from bottomto top.
+    if (!item) {
+        return null;
+    }
+
+    return (
+        <li>
+            {item.label}
+            <button onClick={remove}>delete</button>
+        </li>
+    );
+};
+
+export default connectToStores(
+    Item,
+    [ListStore],
+    ({ getStore, executeAction }, { itemId }) => ({
+        item: getStore(ListStore).getItem(itemId),
+        remove: () => executeAction(removeItem, { itemId }),
+    })
+);

--- a/examples/stale-props/src/List.js
+++ b/examples/stale-props/src/List.js
@@ -1,0 +1,17 @@
+import { connectToStores } from 'fluxible-addons-react';
+import ListStore from './ListStore';
+import Item from './Item';
+
+let List = ({ items }) => {
+    return (
+        <ul>
+            {items.map((itemId) => (
+                <Item key={itemId} itemId={itemId} />
+            ))}
+        </ul>
+    );
+};
+
+export default connectToStores(List, [ListStore], ({ getStore }) => ({
+    items: getStore(ListStore).getItems(),
+}));

--- a/examples/stale-props/src/ListStore.js
+++ b/examples/stale-props/src/ListStore.js
@@ -1,0 +1,47 @@
+import createStore from 'fluxible/addons/createStore';
+
+const ListStore = createStore({
+    storeName: 'ListStore',
+
+    initialize() {
+        this.items = [
+            {
+                id: 1,
+                label: 'init',
+            },
+            {
+                id: 2,
+                label: 'init2',
+            },
+            {
+                id: 3,
+                label: 'init3',
+            },
+        ];
+    },
+
+    handlers: {
+        addItem: 'addItem',
+        removeItem: 'removeItem',
+    },
+
+    addItem(item) {
+        this.items.push(item);
+        this.emitChange();
+    },
+
+    removeItem({ itemId }) {
+        this.items = this.items.filter(({ id }) => id !== itemId);
+        this.emitChange();
+    },
+
+    getItems() {
+        return this.items.map(({ id }) => id);
+    },
+
+    getItem(itemId) {
+        return this.items.find(({ id }) => id === itemId);
+    },
+});
+
+export default ListStore;

--- a/examples/stale-props/src/actions.js
+++ b/examples/stale-props/src/actions.js
@@ -1,0 +1,14 @@
+import generateUUID from 'fluxible/utils/generateUUID';
+
+export function addItem({ dispatch }, { label }) {
+    dispatch('addItem', {
+        id: generateUUID(),
+        label,
+    });
+}
+
+export function removeItem({ dispatch }, { itemId }) {
+    dispatch('removeItem', {
+        itemId,
+    });
+}

--- a/examples/stale-props/src/fluxibleApp.js
+++ b/examples/stale-props/src/fluxibleApp.js
@@ -1,0 +1,8 @@
+import Fluxible from 'fluxible';
+import ListStore from './ListStore';
+
+const fluxibleApp = new Fluxible({});
+
+fluxibleApp.registerStore(ListStore);
+
+export default fluxibleApp;

--- a/examples/stale-props/src/index.js
+++ b/examples/stale-props/src/index.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { FluxibleProvider } from 'fluxible-addons-react';
+import fluxibleApp from './fluxibleApp';
+import App from './App';
+
+const context = fluxibleApp.createContext();
+
+ReactDOM.render(
+    <React.StrictMode>
+        <FluxibleProvider context={context.getComponentContext()}>
+            <App />
+        </FluxibleProvider>
+    </React.StrictMode>,
+    document.getElementById('root')
+);


### PR DESCRIPTION
@redonkulus after going deep on how react-redux works and all the issues that they faced regarding stale props, I was curious to know how fluxible would handle the situation. Since we are not doing any thing special to guarantee that subscriptions are happening from top to bottom (so, child components subscribe before parent components since this is how React works), a simple todo application could crash if no proper measures are taken.

So I did this example to display the issue just to document how one can handle this case.

By the way, I also did a version with the previous implementation with the legacy react context just to check how it would behave. The results are the same.

More info regarding stale props:

- https://blog.isquaredsoftware.com/2018/11/react-redux-history-implementation/
- https://kaihao.dev/posts/Stale-props-and-zombie-children-in-Redux

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
