### PR TITLE
refactor(fluxible-plugin-fetchr): use Fetchr.registerService

### DIFF
--- a/packages/fluxible-plugin-fetchr/lib/fetchr-plugin.js
+++ b/packages/fluxible-plugin-fetchr/lib/fetchr-plugin.js
@@ -151,7 +151,7 @@ module.exports = function fetchrPlugin(options) {
          * @method registerService
          */
         registerService: function registerService(service) {
-            Fetchr.registerFetcher(service);
+            Fetchr.registerService(service);
         },
         /**
          * Get the express middleware. Only works on the server!


### PR DESCRIPTION
Fetchr.registerFetcher is deprecated and should not be used.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
