### PR TITLE
feat(addons-react): make connectToStores stateless

### DIFF
--- a/packages/fluxible-addons-react/src/connectToStores.js
+++ b/packages/fluxible-addons-react/src/connectToStores.js
@@ -37,18 +37,11 @@ function connectToStores(Component, stores, getStateFromStores, options) {
             super(props, context);
             this._isMounted = false;
             this._onStoreChange = this._onStoreChange.bind(this);
-            this.getStateFromStores = this.getStateFromStores.bind(this);
-            this.state = this.getStateFromStores();
-        }
-
-        getStateFromStores(props) {
-            props = props || this.props;
-            return getStateFromStores(this.context, props);
         }
 
         _onStoreChange() {
             if (this._isMounted) {
-                this.setState(this.getStateFromStores());
+                this.forceUpdate();
             }
         }
 
@@ -68,15 +61,13 @@ function connectToStores(Component, stores, getStateFromStores, options) {
             );
         }
 
-        UNSAFE_componentWillReceiveProps(nextProps) {
-            this.setState(this.getStateFromStores(nextProps));
-        }
-
         render() {
+            const storeState = getStateFromStores(this.context, this.props);
+
             return createElement(Component, {
                 ref: this.props.fluxibleRef,
                 ...this.props,
-                ...this.state,
+                ...storeState,
             });
         }
     }


### PR DESCRIPTION
Solves https://github.com/yahoo/fluxible/issues/587

With this change we remove the dependency on `componentWillReceiveProps`
which triggers a bunch of warnings when using React strict mode.

The flow changes as following:

On SSR:

  BEFORE:

  1. Fluxible store would be populated before any component rendering;
  2. Fluxible store would be provided to react components;
  3. Connected components would initially populate their state by
     calling `getStateFromStores` in their construct method;
  4. Connected components would be rendered with the generated component
     state from the construct method.

  AFTER:

  1. Same;
  2. Same;
  3. No more state generation while constructing connected components;
  4. Connected components will generate the state at render time and
     then render.

On Browser:

  BEFORE:

  1. Fluxible store would be rehydrated;
  2. Fluxible store would be provided to react components;
  3. Connected components would initially populate their state by
     calling `getStateFromStores` in their construct method;
  4. Connected components would register to stores on mount;
  5. On new props: connected components would update the component state
     which would trigger a re-render;
  6. On store changes: connected components would update the component
     state which would trigger a re-render.

  AFTER:

  1. Same;
  2. Same;
  3. No more state generation while constructing connected components;
  4. Same;
  5. On new props: the state will be calculated at render time and the
     inner component will be re-rendered;
  6. On store changes: connected components will be forcefully updated
     and behave as if new props were received.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
