### PR TITLE
feat(addons-react): make connectToStores stateless (legacy)

### DIFF
--- a/packages/fluxible-addons-react/connectToStores.js
+++ b/packages/fluxible-addons-react/connectToStores.js
@@ -17,7 +17,6 @@ function createComponent(Component, stores, getStateFromStores, customContextTyp
 
     function StoreConnector(props, context) {
         React.Component.apply(this, arguments);
-        this.state = this.getStateFromStores();
         this._onStoreChange = null;
         this._isMounted = false;
     }
@@ -41,21 +40,15 @@ function createComponent(Component, stores, getStateFromStores, customContextTyp
                 this.context.getStore(Store).removeListener('change', this._onStoreChange);
             }, this);
         },
-        componentWillReceiveProps: function componentWillReceiveProps(nextProps){
-            this.setState(this.getStateFromStores(nextProps));
-        },
-        getStateFromStores: function (props) {
-            props = props || this.props;
-            return getStateFromStores(this.context, props);
-        },
         _onStoreChange: function onStoreChange() {
             if (this._isMounted) {
-                this.setState(this.getStateFromStores());
+                this.forceUpdate();
             }
         },
         render: function render() {
+            var state = getStateFromStores(this.context, this.props)
             var props = Component.prototype && Component.prototype.isReactComponent ? {ref: 'wrappedElement'} : null;
-            return React.createElement(Component, Object.assign({}, this.props, this.state, props));
+            return React.createElement(Component, Object.assign({}, this.props, state, props));
         }
     });
 


### PR DESCRIPTION
@redonkulus since most of the people are still using the old version (and since the changes here shouldn't break anything), I ported #747 for the old fluxible-addons-react. If it's fine for you, could you create a branch starting from `fluxible-addons-react@0.2.16` tag?


 
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
