### PR TITLE
fix(addons-react): prevent fluxibleRef to leak in connected components

### DIFF
--- a/packages/fluxible-addons-react/src/connectToStores.js
+++ b/packages/fluxible-addons-react/src/connectToStores.js
@@ -62,11 +62,12 @@ function connectToStores(Component, stores, getStateFromStores, options) {
         }
 
         render() {
-            const storeState = getStateFromStores(this.context, this.props);
+            const { fluxibleRef, ...props } = this.props;
+            const storeState = getStateFromStores(this.context, props);
 
             return createElement(Component, {
-                ref: this.props.fluxibleRef,
-                ...this.props,
+                ref: fluxibleRef,
+                ...props,
                 ...storeState,
             });
         }
@@ -75,10 +76,12 @@ function connectToStores(Component, stores, getStateFromStores, options) {
     StoreConnector.contextType = FluxibleComponentContext;
 
     const forwarded = forwardRef((props, ref) =>
-        createElement(StoreConnector, {
-            ...props,
-            fluxibleRef: options?.forwardRef ? ref : null,
-        })
+        createElement(
+            StoreConnector,
+            options?.forwardRef
+                ? Object.assign({ fluxibleRef: ref }, props)
+                : props
+        )
     );
     forwarded.displayName = `storeConnector(${
         Component.displayName || Component.name || 'Component'

--- a/packages/fluxible-addons-react/tests/unit/lib/FluxibleComponentContext.test.js
+++ b/packages/fluxible-addons-react/tests/unit/lib/FluxibleComponentContext.test.js
@@ -1,7 +1,7 @@
 const React = require('react');
 const { useContext } = require('react');
 const { renderToString } = require('react-dom/server');
-const { FluxibleComponent, FluxibleComponentContext } = require('../../../');
+const { FluxibleProvider, FluxibleComponentContext } = require('../../../');
 
 describe('FluxibleComponentContext', () => {
     it('provides access to getStore and executeAction', () => {
@@ -20,9 +20,9 @@ describe('FluxibleComponentContext', () => {
         };
 
         renderToString(
-            <FluxibleComponent context={context}>
+            <FluxibleProvider context={context}>
                 <Component />
-            </FluxibleComponent>
+            </FluxibleProvider>
         );
 
         expect(context.getStore).toHaveBeenCalledTimes(1);

--- a/packages/fluxible-addons-react/tests/unit/lib/connectToStores.test.js
+++ b/packages/fluxible-addons-react/tests/unit/lib/connectToStores.test.js
@@ -8,7 +8,7 @@ const {
 } = require('react');
 const TestRenderer = require('react-test-renderer');
 const createMockComponentContext = require('fluxible/utils/createMockComponentContext');
-const { connectToStores, FluxibleComponent } = require('../../../');
+const { connectToStores, FluxibleProvider } = require('../../../');
 const FooStore = require('../../fixtures/stores/FooStore');
 const BarStore = require('../../fixtures/stores/BarStore');
 
@@ -40,9 +40,9 @@ const renderComponent = (Component, ref) => {
     const context = createMockComponentContext({ stores });
 
     const app = TestRenderer.create(
-        <FluxibleComponent context={context}>
+        <FluxibleProvider context={context}>
             <Component ref={ref} />
-        </FluxibleComponent>
+        </FluxibleProvider>
     );
 
     return { app, context };


### PR DESCRIPTION
I'm migrating a huge app to the newer fluxible-addons-react/fluxible-router. It has many enzyme tests that checks if the result of `getStateFromStore` is correct. Example:

```js
describe('MyComponentConnected', () => {
  it('pass correct props to inner component', () => {
    const wrapper = mount(<MyComponentConnected />);
    const innerComponent = wrapper.find(MyComponent);

    const expectedProps = {
       foo: 'bar'
    };

    expect(innerComponent.props()).to.deep.equal(expectedProps);
  });
});
```
Due to the lack of attention, we were forwarding the internal `fluxibleRef` prop to the inner component. The test above would fail since MyComponent props would be:

```js
{
  fluxibleRef: null,
  foo: 'bar',
}
```

`fluxibleRef` is a implementation detail that we use internally to forward the user ref between the component created with `forwardRef` and `StoreConnector` ((see: https://github.com/yahoo/fluxible/blob/2ba3719c1dd5418b8af8c3ba2241e581e3e4c076/packages/fluxible-addons-react/src/connectToStores.js#L77) ). It should never be passed to the user component as `fluxibleRef` (only as ref). 

This patch fixes this issue by only passing the rightful props to the inner component.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
