### PR TITLE
Add cause for thrown error

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint .",
-    "test": "lerna run lint --since --stream && jest"
+    "test": "lerna run lint --since --stream && jest --forceExit"
   },
   "devDependencies": {
     "@babel/cli": "^7.11.6",

--- a/packages/dispatchr/lib/Dispatcher.js
+++ b/packages/dispatchr/lib/Dispatcher.js
@@ -188,7 +188,7 @@ Dispatcher.prototype._throwOrCallErrorHandler =
                 context
             );
         } else {
-            throw new Error(message);
+            throw new Error(message, { cause: meta && meta.error });
         }
     };
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

## Goal
Allow for those catching this error to see the cause (and get the stack) rather than receive a message without stack

Docs on cause: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#differentiate_between_similar_errors