### PR TITLE
fix: build by adding missing dependencies

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -47,6 +47,8 @@
     "superagent": "^3.8.3"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-class-properties": "^7.18.6",
+    "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
     "@istanbuljs/nyc-config-babel": "^3.0.0",
     "babel-eslint": "^10.0.0",
     "babel-loader": "^8.2.2",


### PR DESCRIPTION
```
Running "webpack:prod" (webpack) task
Fatal error: Cannot find package '@babel/plugin-proposal-class-properties' imported from ...
```

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
