### PR TITLE
chore: removed legacy transforms

### DIFF
--- a/site/.babelrc
+++ b/site/.babelrc
@@ -1,9 +1,5 @@
 {
     "presets": ["@babel/preset-env", "@babel/preset-react"],
-    "plugins": [
-        "@babel/plugin-proposal-class-properties",
-        "@babel/plugin-proposal-object-rest-spread"
-    ],
     "env": {
         "test": {
             "plugins": ["istanbul"]

--- a/site/package.json
+++ b/site/package.json
@@ -47,8 +47,6 @@
     "superagent": "^3.8.3"
   },
   "devDependencies": {
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
-    "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
     "@istanbuljs/nyc-config-babel": "^3.0.0",
     "babel-eslint": "^10.0.0",
     "babel-loader": "^8.2.2",


### PR DESCRIPTION
1. These really should be in `dependencies` not `devDependencies` since babel/runtime is used.
2. These are really old and now part of the standard and should just be dropped